### PR TITLE
add pulling to central as backup

### DIFF
--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/provisionRun/provisionRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/provisionRun/provisionRun.ts
@@ -71,9 +71,9 @@ export async function provisionRun({
       ],
       portBindings: [],
       commandsToRun: ['python', '/workspace/system/entry_provision.py'],
-      onContainerExitSuccess: async (containerId) => resolve(undefined),
-      onContainerExitError: async (_, error) => reject(new Error(error)),
-    })
+      onContainerExitSuccess: () => resolve(undefined),
+      onContainerExitError: (_, error) => reject(new Error(error)),
+    }).catch(reject)
   })
 
   const pathRunKits = path.join(pathRun, 'runKits')

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
@@ -1,7 +1,10 @@
 import path from 'path'
 import { provisionRun } from './provisionRun/provisionRun.js'
 import { reservePort } from './portManagement.js'
-import { launchNode } from '../../nodeManager/launchNode.js'
+import {
+  ensureDockerImageReady,
+  launchNode,
+} from '../../nodeManager/launchNode.js'
 import uploadToFileServer from './uploadToFileServer.js'
 import reportRunError from '../../report/reportRunError.js'
 import reportRunComplete from '../../report/reportRunComplete.js'
@@ -41,6 +44,9 @@ export default async function startRun({
   }
 
   try {
+    // Refresh floating tags once, then pin both run phases to the same local image.
+    const resolvedImageName = await ensureDockerImageReady(imageName)
+
     // Reserve ports for federated learning and admin servers
     const {
       port: reservedFedLearnPort,
@@ -56,7 +62,7 @@ export default async function startRun({
     // Provision the run
     logger.info(`Provisioning run ${runId}`)
     await provisionRun({
-      imageName,
+      imageName: resolvedImageName,
       activeParticipants,
       pathRun,
       computationParameters,
@@ -80,7 +86,7 @@ export default async function startRun({
     // Launch the Docker node
     await launchNode({
       containerService: 'docker',
-      imageName,
+      imageName: resolvedImageName,
       directoriesToMount: [
         {
           hostDirectory: pathCentralNodeRunKit,

--- a/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -76,7 +76,7 @@ const launchDockerNode = async ({
 
   try {
     await isDockerRunning()
-    await doesImageExist(imageName)
+    await ensureDockerImageReady(imageName)
 
     // Create the container
     const container = await docker.createContainer({
@@ -173,4 +173,54 @@ const doesImageExist = async (imageName: string) => {
       }`,
     )
   }
+}
+
+const shouldPullBeforeRun = (imageName: string): boolean => {
+  if (imageName.includes('@sha256:')) {
+    return false
+  }
+
+  const imageWithoutRegistryPort = imageName.includes('/')
+    ? imageName.substring(imageName.lastIndexOf('/') + 1)
+    : imageName
+
+  return !imageWithoutRegistryPort.includes(':') || imageName.endsWith(':latest')
+}
+
+const pullDockerImage = async (imageName: string): Promise<void> => {
+  logger.info(`Pulling Docker image before run: ${imageName}`)
+
+  await new Promise<void>((resolve, reject) => {
+    docker.pull(imageName, (error: Error | null, stream: NodeJS.ReadableStream | undefined) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      if (!stream) {
+        reject(new Error(`Docker did not return a pull stream for ${imageName}`))
+        return
+      }
+
+      docker.modem.followProgress(stream, (progressError) => {
+        if (progressError) {
+          reject(progressError)
+          return
+        }
+
+        resolve()
+      })
+    })
+  })
+
+  logger.info(`Docker image pull completed: ${imageName}`)
+}
+
+const ensureDockerImageReady = async (imageName: string): Promise<void> => {
+  if (shouldPullBeforeRun(imageName)) {
+    await pullDockerImage(imageName)
+    return
+  }
+
+  await doesImageExist(imageName)
 }

--- a/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -75,12 +75,11 @@ const launchDockerNode = async ({
   })
 
   try {
-    await isDockerRunning()
-    await ensureDockerImageReady(imageName)
+    const resolvedImageName = await ensureDockerImageReady(imageName)
 
     // Create the container
     const container = await docker.createContainer({
-      Image: imageName,
+      Image: resolvedImageName,
       Cmd: commandsToRun,
       ExposedPorts: exposedPorts,
       HostConfig: {
@@ -156,22 +155,18 @@ const isDockerRunning = async () => {
   }
 }
 
-const doesImageExist = async (imageName: string) => {
+const getLocalDockerImageId = async (
+  imageName: string,
+): Promise<string | undefined> => {
   try {
-    const images = await docker.listImages({
-      filters: { reference: [imageName] },
-    })
-    if (images.length === 0) {
-      throw new Error(
-        `Image "${imageName}" does not exist. Please pull the image or verify its name.`,
-      )
-    }
+    const image = await docker.getImage(imageName).inspect()
+    return image.Id
   } catch (error) {
-    throw new Error(
-      `Failed to check existence of image "${imageName}": ${
-        (error as Error).message
-      }`,
-    )
+    if ((error as { statusCode?: number }).statusCode === 404) {
+      return undefined
+    }
+
+    throw error
   }
 }
 
@@ -216,11 +211,34 @@ const pullDockerImage = async (imageName: string): Promise<void> => {
   logger.info(`Docker image pull completed: ${imageName}`)
 }
 
-const ensureDockerImageReady = async (imageName: string): Promise<void> => {
+export const ensureDockerImageReady = async (
+  imageName: string,
+): Promise<string> => {
+  await isDockerRunning()
+
   if (shouldPullBeforeRun(imageName)) {
-    await pullDockerImage(imageName)
-    return
+    try {
+      await pullDockerImage(imageName)
+    } catch (error) {
+      const localImageId = await getLocalDockerImageId(imageName)
+      if (!localImageId) {
+        throw error
+      }
+
+      logger.warn(
+        `Failed to refresh Docker image ${imageName}; using cached image ${localImageId}`,
+        { error },
+      )
+      return localImageId
+    }
   }
 
-  await doesImageExist(imageName)
+  const localImageId = await getLocalDockerImageId(imageName)
+  if (!localImageId) {
+    throw new Error(
+      `Image "${imageName}" does not exist. Please pull the image or verify its name.`,
+    )
+  }
+
+  return localImageId
 }


### PR DESCRIPTION
 ## Summary

  Adds automatic Docker image refresh for the central federated client when computations use an untagged or latest image.

  - Resolves the refreshed image to an immutable local ID.
  - Uses the same image for provisioning and execution.
  - Falls back to a cached image during registry outages.
  - Propagates launch failures instead of hanging.
  - Leaves explicit tags and digests locally pinned.