### PR TITLE
UI: consortium wizard step gating, member flow improvements, consortium details page tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+    "git.ignoreLimitWarning": true
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/Computation.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/Computation.tsx
@@ -13,9 +13,11 @@ import { electronApi } from '../../../apis/electronApi/electronApi'
 
 interface ComputationDisplayProps {
   computation: Maybe<ComputationType> | undefined;
+  showDownloadInstructions?: boolean;
+  onImageDownloaded?: () => void;
 }
 
-export default function Computation({ computation }: ComputationDisplayProps) {
+export default function Computation({ computation, showDownloadInstructions, onImageDownloaded }: ComputationDisplayProps) {
   const { isLeader, refetch } = useConsortiumDetailsContext()
   const [copied, setCopied] = useState(false)
   const [isSingularity, setIsSingularity] = useState(false)
@@ -136,7 +138,7 @@ export default function Computation({ computation }: ComputationDisplayProps) {
             marginBottom: 1,
           }}
         >
-          <TerminalWindow command={imageDownloadUrl} />
+          <TerminalWindow command={imageDownloadUrl} showInstructions={showDownloadInstructions} onImageExists={onImageDownloaded} />
         </Box>
         <HashLink
           id='compnotes-anchor'

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/Computation.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/Computation.tsx
@@ -14,10 +14,14 @@ import { electronApi } from '../../../apis/electronApi/electronApi'
 interface ComputationDisplayProps {
   computation: Maybe<ComputationType> | undefined;
   showDownloadInstructions?: boolean;
-  onImageDownloaded?: () => void;
+  onImageDownloaded?: (downloaded: boolean) => void;
 }
 
-export default function Computation({ computation, showDownloadInstructions, onImageDownloaded }: ComputationDisplayProps) {
+export default function Computation({
+  computation,
+  showDownloadInstructions,
+  onImageDownloaded,
+}: ComputationDisplayProps) {
   const { isLeader, refetch } = useConsortiumDetailsContext()
   const [copied, setCopied] = useState(false)
   const [isSingularity, setIsSingularity] = useState(false)
@@ -138,7 +142,11 @@ export default function Computation({ computation, showDownloadInstructions, onI
             marginBottom: 1,
           }}
         >
-          <TerminalWindow command={imageDownloadUrl} showInstructions={showDownloadInstructions} onImageExists={onImageDownloaded} />
+          <TerminalWindow
+            command={imageDownloadUrl}
+            showInstructions={showDownloadInstructions}
+            onImageExists={onImageDownloaded}
+          />
         </Box>
         <HashLink
           id='compnotes-anchor'

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/TerminalWindow.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/TerminalWindow.tsx
@@ -3,6 +3,7 @@ import { electronApi } from '../../../apis/electronApi/electronApi'
 import ScrollToBottom from 'react-scroll-to-bottom'
 import { Box, Button, Typography, CircularProgress } from '@mui/material'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ArrowDown from '../../../assets/arrow-down.png'
 
 const ScrollToBottomWrapper = forwardRef<
   HTMLDivElement,
@@ -16,7 +17,7 @@ const MATCHERS = [
   /docker\.io\/coinstacteam\/nfc-single-round-ridge-regression-freesurfer:latest/i,
 ]
 
-const TerminalWindow: React.FC<{ command: string }> = ({ command }) => {
+const TerminalWindow: React.FC<{ command: string; showInstructions?: boolean; onImageExists?: () => void }> = ({ command, showInstructions, onImageExists }) => {
   const [output, setOutput] = useState<string[]>([])
   const [isTerminalReady, setTerminalReady] = useState(false)
   const [showTerminal, setShowTerminal] = useState(false)
@@ -28,6 +29,7 @@ const TerminalWindow: React.FC<{ command: string }> = ({ command }) => {
   const imageExistsRef = useRef(false)
   useEffect(() => {
     imageExistsRef.current = imageExists
+    if (imageExists) onImageExists?.()
   }, [imageExists])
 
   const {
@@ -168,6 +170,25 @@ const TerminalWindow: React.FC<{ command: string }> = ({ command }) => {
 
   return (
     <>
+      {showInstructions && !imageExists && !showTerminal && !isPulling && (
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-end', mb: 1 }}>
+          {/* <img
+            src={ArrowDown}
+            alt='arrow pointing at button'
+            style={{ width: '70px', rotate: '-90deg', flexShrink: 0, transform: 'scaleY(-1)' }}
+          /> */}
+          <Box>
+            <Typography variant='body2' fontWeight='bold' color='error'>
+              {isSingularity ? 'Click "Run Singularity Pull" below to download the computation image.' : 'Click "Run Docker Pull" below to download the computation image.'}
+            </Typography>
+            {!isSingularity && (
+              <Typography variant='body2' color='text.secondary'>
+                You'll need Docker installed on your machine for this to work.
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      )}
       {!imageExists && !showTerminal && !isPulling && (
         <Button
           variant='contained'

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/TerminalWindow.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Computation/TerminalWindow.tsx
@@ -3,7 +3,6 @@ import { electronApi } from '../../../apis/electronApi/electronApi'
 import ScrollToBottom from 'react-scroll-to-bottom'
 import { Box, Button, Typography, CircularProgress } from '@mui/material'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import ArrowDown from '../../../assets/arrow-down.png'
 
 const ScrollToBottomWrapper = forwardRef<
   HTMLDivElement,
@@ -17,7 +16,11 @@ const MATCHERS = [
   /docker\.io\/coinstacteam\/nfc-single-round-ridge-regression-freesurfer:latest/i,
 ]
 
-const TerminalWindow: React.FC<{ command: string; showInstructions?: boolean; onImageExists?: () => void }> = ({ command, showInstructions, onImageExists }) => {
+const TerminalWindow: React.FC<{
+  command: string;
+  showInstructions?: boolean;
+  onImageExists?: (exists: boolean) => void;
+}> = ({ command, showInstructions, onImageExists }) => {
   const [output, setOutput] = useState<string[]>([])
   const [isTerminalReady, setTerminalReady] = useState(false)
   const [showTerminal, setShowTerminal] = useState(false)
@@ -29,8 +32,16 @@ const TerminalWindow: React.FC<{ command: string; showInstructions?: boolean; on
   const imageExistsRef = useRef(false)
   useEffect(() => {
     imageExistsRef.current = imageExists
-    if (imageExists) onImageExists?.()
-  }, [imageExists])
+    onImageExists?.(imageExists)
+  }, [imageExists, onImageExists])
+
+  useEffect(() => {
+    imageExistsRef.current = false
+    setImageExists(false)
+    setOutput([])
+    setShowTerminal(false)
+    setPullError(null)
+  }, [command])
 
   const {
     spawnTerminal,
@@ -114,7 +125,7 @@ const TerminalWindow: React.FC<{ command: string; showInstructions?: boolean; on
         removeTerminalOutputListener()
       }
     }
-  }, [isSingularity]) // run when singularity status changes
+  }, [isSingularity, command]) // rerun when the selected image changes
 
   // Set up Singularity pull output listener when Singularity mode is active
   useEffect(() => {
@@ -172,14 +183,11 @@ const TerminalWindow: React.FC<{ command: string; showInstructions?: boolean; on
     <>
       {showInstructions && !imageExists && !showTerminal && !isPulling && (
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-end', mb: 1 }}>
-          {/* <img
-            src={ArrowDown}
-            alt='arrow pointing at button'
-            style={{ width: '70px', rotate: '-90deg', flexShrink: 0, transform: 'scaleY(-1)' }}
-          /> */}
           <Box>
             <Typography variant='body2' fontWeight='bold' color='error'>
-              {isSingularity ? 'Click "Run Singularity Pull" below to download the computation image.' : 'Click "Run Docker Pull" below to download the computation image.'}
+              {isSingularity
+                ? 'Click "Run Singularity Pull" below to download the computation image.'
+                : 'Click "Run Docker Pull" below to download the computation image.'}
             </Typography>
             {!isSingularity && (
               <Typography variant='body2' color='text.secondary'>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useMemo } from 'react'
 import { Computation } from '../../../apis/centralApi/generated/graphql'
-import { Box, Typography, Card, CardContent } from '@mui/material'
+import { Box, Typography, Card, CardContent, IconButton, Tooltip } from '@mui/material'
+import OpenInFullIcon from '@mui/icons-material/OpenInFull'
+import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen'
 import { Maybe } from 'graphql/jsutils/Maybe'
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -9,9 +11,11 @@ import { useConsortiumDetailsContext } from '../ConsortiumDetailsContext'
 const slugify = (s: string) =>
   s.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '')
 
-const ComputationDisplay: React.FC<{ notesHeading: boolean }> = ({
-  notesHeading,
-}) => {
+const ComputationDisplay: React.FC<{
+  notesHeading: boolean;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+}> = ({ notesHeading, expanded, onToggleExpand }) => {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const computation =
     consortiumDetails?.studyConfiguration?.computation as Maybe<Computation>
@@ -92,12 +96,23 @@ const ComputationDisplay: React.FC<{ notesHeading: boolean }> = ({
     >
       <div id='compnotes' />{/* For Notes anchor placement at 800px wide */}
       <CardContent>
-        {notesHeading && (
-          <Typography fontSize='11px'>Computation Notes:</Typography>
-        )}
-        <Typography variant='h5' fontWeight='600' color='black'>
-          {title}
-        </Typography>
+        <Box display='flex' justifyContent='space-between' alignItems='flex-start'>
+          <Box flex={1}>
+            {notesHeading && (
+              <Typography fontSize='11px'>Computation Notes:</Typography>
+            )}
+            <Typography variant='h5' fontWeight='600' color='black'>
+              {title}
+            </Typography>
+          </Box>
+          {onToggleExpand && (
+            <Tooltip title={expanded ? 'Collapse' : 'Expand'}>
+              <IconButton size='small' onClick={onToggleExpand} sx={{ mt: '-4px', mr: '-8px', display: { xs: 'none', md: 'flex' } }}>
+                {expanded ? <CloseFullscreenIcon fontSize='small' /> : <OpenInFullIcon fontSize='small' />}
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
         <Typography variant='body2' color='textSecondary'>
           {imageName}
         </Typography>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ComputationDisplay/ComputationDisplay.tsx
@@ -107,8 +107,14 @@ const ComputationDisplay: React.FC<{
           </Box>
           {onToggleExpand && (
             <Tooltip title={expanded ? 'Collapse' : 'Expand'}>
-              <IconButton size='small' onClick={onToggleExpand} sx={{ mt: '-4px', mr: '-8px', display: { xs: 'none', md: 'flex' } }}>
-                {expanded ? <CloseFullscreenIcon fontSize='small' /> : <OpenInFullIcon fontSize='small' />}
+              <IconButton
+                size='small'
+                onClick={onToggleExpand}
+                sx={{ mt: '-4px', mr: '-8px', display: { xs: 'none', md: 'flex' } }}
+              >
+                {expanded
+                  ? <CloseFullscreenIcon fontSize='small' />
+                  : <OpenInFullIcon fontSize='small' />}
               </IconButton>
             </Tooltip>
           )}

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumDetailsPage.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumDetailsPage.tsx
@@ -134,6 +134,7 @@ export function ConsortiumDetailsPage() {
   // Delete dialog state
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
+  const [notesExpanded, setNotesExpanded] = useState<boolean>(false)
 
   const handlePrivacyChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
     updateConsortiumPrivacy(checked).catch(() => {})
@@ -167,74 +168,139 @@ export function ConsortiumDetailsPage() {
           </Grid>
         </Grid>
 
-        <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-
-          {isLeader && hasComputation && <StartRunButton />}
-          {isActive && <DirectorySelect />}
-
-          <Members
-            members={members}
-            activeMembers={activeMembers}
-            readyMembers={readyMembers}
-            leader={leader}
-          />
-
-          {(isLeader || hasLeaderNotesContent) && (
-            <ConsortiumLeaderNotes
-              consortiumLeaderNotes={leaderNotes || ''}
-              showAccordion
-            />
-          )}
-        </Grid>
-
-        <Grid size={{ xs: 12, sm: 6, md: 4 }} className='consortium-details-grid-2'>
-          <LatestRun />
-          <Computation computation={studyConfiguration?.computation} />
-
-          {/* Parameters area: two simple cases */}
-          {hasComputation && (
-            <Box borderRadius={2} marginBottom={0} bgcolor='white'>
-              {supportsLocal ? (
-                <>
-                  <Tabs
-                    value={tab}
-                    onChange={(_e, v) => setTab(v)}
-                    variant='fullWidth'
-                    textColor='inherit'
-                    TabIndicatorProps={{ sx: { backgroundColor: '#0066ff' } }}
-                    sx={{
-                      '& .MuiTab-root.Mui-selected': { color: '#0066ff' },
-                      '& .MuiTab-root': {
-                        color: 'inherit',
-                        '&:hover': { color: '#0066ff' },
-                        '&:focus': { color: '#0066ff' },
-                      },
-                    }}
-                  >
-                    <Tab label='Global Settings' value='global' />
-                    <Tab label='Local Settings' value='local' />
-                  </Tabs>
-
-                  <Box role='tabpanel' hidden={tab !== 'global'} id='tabpanel-global' aria-labelledby='tab-global'>
-                    {tab === 'global' && <ComputationParameters />}
+        {notesExpanded ? (
+          <>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Box display='flex' flexDirection='column'>
+                {isLeader && hasComputation && <StartRunButton />}
+                {isActive && <DirectorySelect />}
+                <Members
+                  members={members}
+                  activeMembers={activeMembers}
+                  readyMembers={readyMembers}
+                  leader={leader}
+                />
+                {(isLeader || hasLeaderNotesContent) && (
+                  <ConsortiumLeaderNotes
+                    consortiumLeaderNotes={leaderNotes || ''}
+                    showAccordion
+                  />
+                )}
+                <LatestRun />
+                <Computation computation={studyConfiguration?.computation} />
+                {hasComputation && (
+                  <Box borderRadius={2} marginBottom={0} bgcolor='white'>
+                    {supportsLocal ? (
+                      <>
+                        <Tabs
+                          value={tab}
+                          onChange={(_e, v) => setTab(v)}
+                          variant='fullWidth'
+                          textColor='inherit'
+                          TabIndicatorProps={{ sx: { backgroundColor: '#0066ff' } }}
+                          sx={{
+                            '& .MuiTab-root.Mui-selected': { color: '#0066ff' },
+                            '& .MuiTab-root': {
+                              color: 'inherit',
+                              '&:hover': { color: '#0066ff' },
+                              '&:focus': { color: '#0066ff' },
+                            },
+                          }}
+                        >
+                          <Tab label='Global Settings' value='global' />
+                          <Tab label='Local Settings' value='local' />
+                        </Tabs>
+                        <Box role='tabpanel' hidden={tab !== 'global'} id='tabpanel-global' aria-labelledby='tab-global'>
+                          {tab === 'global' && <ComputationParameters />}
+                        </Box>
+                        <Box role='tabpanel' hidden={tab !== 'local'} id='tabpanel-local' aria-labelledby='tab-local'>
+                          {tab === 'local' && <ComputationLocalParameters />}
+                        </Box>
+                      </>
+                    ) : (
+                      <Box>
+                        <ComputationParameters />
+                      </Box>
+                    )}
                   </Box>
-                  <Box role='tabpanel' hidden={tab !== 'local'} id='tabpanel-local' aria-labelledby='tab-local'>
-                    {tab === 'local' && <ComputationLocalParameters />}
-                  </Box>
-                </>
-              ) : (
-                // Only Global, no tabs
-                <Box>
-                  <ComputationParameters />
+                )}
+              </Box>
+            </Grid>
+            <Grid size={{ xs: 12, md: 8 }} className='consortium-details-grid-3'>
+              <ComputationDisplay
+                notesHeading
+                expanded={notesExpanded}
+                onToggleExpand={() => setNotesExpanded((v) => !v)}
+              />
+            </Grid>
+          </>
+        ) : (
+          <>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+              {isLeader && hasComputation && <StartRunButton />}
+              {isActive && <DirectorySelect />}
+              <Members
+                members={members}
+                activeMembers={activeMembers}
+                readyMembers={readyMembers}
+                leader={leader}
+              />
+              {(isLeader || hasLeaderNotesContent) && (
+                <ConsortiumLeaderNotes
+                  consortiumLeaderNotes={leaderNotes || ''}
+                  showAccordion
+                />
+              )}
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} className='consortium-details-grid-2'>
+              <LatestRun />
+              <Computation computation={studyConfiguration?.computation} />
+              {hasComputation && (
+                <Box borderRadius={2} marginBottom={0} bgcolor='white'>
+                  {supportsLocal ? (
+                    <>
+                      <Tabs
+                        value={tab}
+                        onChange={(_e, v) => setTab(v)}
+                        variant='fullWidth'
+                        textColor='inherit'
+                        TabIndicatorProps={{ sx: { backgroundColor: '#0066ff' } }}
+                        sx={{
+                          '& .MuiTab-root.Mui-selected': { color: '#0066ff' },
+                          '& .MuiTab-root': {
+                            color: 'inherit',
+                            '&:hover': { color: '#0066ff' },
+                            '&:focus': { color: '#0066ff' },
+                          },
+                        }}
+                      >
+                        <Tab label='Global Settings' value='global' />
+                        <Tab label='Local Settings' value='local' />
+                      </Tabs>
+                      <Box role='tabpanel' hidden={tab !== 'global'} id='tabpanel-global' aria-labelledby='tab-global'>
+                        {tab === 'global' && <ComputationParameters />}
+                      </Box>
+                      <Box role='tabpanel' hidden={tab !== 'local'} id='tabpanel-local' aria-labelledby='tab-local'>
+                        {tab === 'local' && <ComputationLocalParameters />}
+                      </Box>
+                    </>
+                  ) : (
+                    <Box>
+                      <ComputationParameters />
+                    </Box>
+                  )}
                 </Box>
               )}
-            </Box>
-          )}
-        </Grid>
-
-        <Grid size={{ sm: 12, md: 4 }} className='consortium-details-grid-3'>
-          <ComputationDisplay notesHeading />
-        </Grid>
+            </Grid>
+            <Grid size={{ sm: 12, md: 4 }} className='consortium-details-grid-3'>
+              <ComputationDisplay
+                notesHeading
+                expanded={notesExpanded}
+                onToggleExpand={() => setNotesExpanded((v) => !v)}
+              />
+            </Grid>
+          </>
+        )}
       </Grid>
 
       {/* Invite Modal */}

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumDetailsPage.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumDetailsPage.tsx
@@ -143,18 +143,19 @@ export function ConsortiumDetailsPage() {
   return (
     <>
       <Grid container spacing={2} padding={2}>
-          <Grid 
-            container
-            size={12} 
-            spacing={0} 
-            padding={0} 
-          >
+        <Grid
+          container
+          size={12}
+          spacing={0}
+          padding={0}
+        >
           <Grid size={{ xs: 12, sm: 6 }} justifyContent='flex-start' alignItems='bottom'>
             <TitleAndDescription title={title} description={description} />
           </Grid>
-          <Grid 
-            size={{ xs: 12, sm: 6 }}  
-            alignItems='bottom'>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            alignItems='bottom'
+          >
             <ConsortiumActions
               consortiumId={consortiumId}
               isLeader={isLeader}
@@ -210,7 +211,12 @@ export function ConsortiumDetailsPage() {
                           <Tab label='Global Settings' value='global' />
                           <Tab label='Local Settings' value='local' />
                         </Tabs>
-                        <Box role='tabpanel' hidden={tab !== 'global'} id='tabpanel-global' aria-labelledby='tab-global'>
+                        <Box
+                          role='tabpanel'
+                          hidden={tab !== 'global'}
+                          id='tabpanel-global'
+                          aria-labelledby='tab-global'
+                        >
                           {tab === 'global' && <ComputationParameters />}
                         </Box>
                         <Box role='tabpanel' hidden={tab !== 'local'} id='tabpanel-local' aria-labelledby='tab-local'>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumLeaderNotes/ConsortiumLeaderNotes.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/ConsortiumLeaderNotes/ConsortiumLeaderNotes.tsx
@@ -19,6 +19,8 @@ export default function ConsortiumLeaderNotes({
     isLeader,
   } = useConsortiumLeaderNotes(consortiumLeaderNotes)
 
+  if (!isLeader && !consortiumLeaderNotes?.trim()) return null
+
   return (
     <Box
       p={2}

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useDirectorySelect } from './useDirectorySelect'
 import { DirectorySelectDisplay } from './DirectorySelectDisplay'
 import { useUserState } from '../../../contexts/UserStateContext'
@@ -5,9 +6,10 @@ import { useCentralApi } from '../../../apis/centralApi/centralApi'
 import { useParams } from 'react-router-dom'
 import { useConsortiumDetailsContext } from '../ConsortiumDetailsContext'
 
-export default function DirectorySelect() {
+export default function DirectorySelect({ showReadyToggle = true, onDirectorySet }: { showReadyToggle?: boolean; onDirectorySet?: (isSet: boolean) => void }) {
   const {
     editableValue,
+    originalValue,
     changeValue,
     saveEditedValue,
     startEdit,
@@ -23,6 +25,10 @@ export default function DirectorySelect() {
   const { data: { readyMembers, activeMembers }, refetch } = useConsortiumDetailsContext()
 
   const isActive = activeMembers.some((m) => m.id === userId)
+
+  useEffect(() => {
+    onDirectorySet?.(!!originalValue)
+  }, [originalValue])
   const isReady = readyMembers.some((m) => m.id === userId)
 
   const handleSetReady = async (ready: boolean) => {
@@ -46,6 +52,7 @@ export default function DirectorySelect() {
       onStartEdit={startEdit}
       isActive={isActive}
       isReady={isReady}
+      showReadyToggle={showReadyToggle}
       onSetReady={handleSetReady}
     />
   )

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
@@ -1,5 +1,9 @@
 import { useDirectorySelect } from './useDirectorySelect'
 import { DirectorySelectDisplay } from './DirectorySelectDisplay'
+import { useUserState } from '../../../contexts/UserStateContext'
+import { useCentralApi } from '../../../apis/centralApi/centralApi'
+import { useParams } from 'react-router-dom'
+import { useConsortiumDetailsContext } from '../ConsortiumDetailsContext'
 
 export default function DirectorySelect() {
   const {
@@ -13,6 +17,23 @@ export default function DirectorySelect() {
     openDirectoryDialogHandler,
   } = useDirectorySelect()
 
+  const { userId } = useUserState()
+  const { consortiumSetMemberReady } = useCentralApi()
+  const consortiumId = useParams<{ consortiumId: string }>().consortiumId as string
+  const { data: { readyMembers, activeMembers }, refetch } = useConsortiumDetailsContext()
+
+  const isActive = activeMembers.some((m) => m.id === userId)
+  const isReady = readyMembers.some((m) => m.id === userId)
+
+  const handleSetReady = async (ready: boolean) => {
+    try {
+      await consortiumSetMemberReady({ consortiumId, ready })
+      refetch()
+    } catch (error) {
+      console.error('Failed to update ready status:', error)
+    }
+  }
+
   return (
     <DirectorySelectDisplay
       directory={editableValue}
@@ -23,6 +44,9 @@ export default function DirectorySelect() {
       onSaveDirectory={saveEditedValue}
       onCancelEdit={cancelEdit}
       onStartEdit={startEdit}
+      isActive={isActive}
+      isReady={isReady}
+      onSetReady={handleSetReady}
     />
   )
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelect.tsx
@@ -6,7 +6,13 @@ import { useCentralApi } from '../../../apis/centralApi/centralApi'
 import { useParams } from 'react-router-dom'
 import { useConsortiumDetailsContext } from '../ConsortiumDetailsContext'
 
-export default function DirectorySelect({ showReadyToggle = true, onDirectorySet }: { showReadyToggle?: boolean; onDirectorySet?: (isSet: boolean) => void }) {
+export default function DirectorySelect({
+  showReadyToggle = true,
+  onDirectorySet,
+}: {
+  showReadyToggle?: boolean;
+  onDirectorySet?: (isSet: boolean) => void;
+}) {
   const {
     editableValue,
     originalValue,
@@ -43,6 +49,7 @@ export default function DirectorySelect({ showReadyToggle = true, onDirectorySet
   return (
     <DirectorySelectDisplay
       directory={editableValue}
+      hasSavedDirectory={!!originalValue}
       isEditing={isEditing}
       isDifferent={isDifferent}
       onDirectoryChange={changeValue}

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
@@ -18,6 +18,7 @@ interface DirectorySelectDisplayProps {
   isDifferent: boolean; // Positive flag for save
   isActive: boolean;
   isReady: boolean;
+  showReadyToggle?: boolean;
   onDirectoryChange: (newDirectory: string) => void;
   onSaveDirectory: () => void;
   onCancelEdit: () => void;
@@ -32,6 +33,7 @@ export function DirectorySelectDisplay({
   isDifferent,
   isActive,
   isReady,
+  showReadyToggle = true,
   onDirectoryChange,
   onOpenDirectoryDialog,
   onSaveDirectory,
@@ -155,7 +157,7 @@ export function DirectorySelectDisplay({
             </Button>
           )}
           {/* Ready toggle — right-justified, only when directory is set */}
-          {!!directory && (
+          {showReadyToggle && !!directory && (
             <FormControlLabel
               label='Ready'
               labelPlacement='start'

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
@@ -2,7 +2,9 @@ import { useRef } from 'react'
 import {
   Box,
   Button,
+  FormControlLabel,
   InputAdornment,
+  Switch,
   TextField,
   Tooltip,
   Typography,
@@ -14,22 +16,28 @@ interface DirectorySelectDisplayProps {
   directory: string;
   isEditing: boolean;
   isDifferent: boolean; // Positive flag for save
+  isActive: boolean;
+  isReady: boolean;
   onDirectoryChange: (newDirectory: string) => void;
   onSaveDirectory: () => void;
   onCancelEdit: () => void;
   onStartEdit: () => void; // Explicit start edit function
   onOpenDirectoryDialog: () => void;
+  onSetReady: (ready: boolean) => void;
 }
 
 export function DirectorySelectDisplay({
   directory,
   isEditing,
   isDifferent,
+  isActive,
+  isReady,
   onDirectoryChange,
   onOpenDirectoryDialog,
   onSaveDirectory,
   onCancelEdit,
   onStartEdit,
+  onSetReady,
 }: DirectorySelectDisplayProps) {
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -108,7 +116,7 @@ export function DirectorySelectDisplay({
             <Typography fontSize='small' align='center'>or</Typography>
           </Box>
         )}
-        <Box display='flex' gap={1}>
+        <Box display='flex' gap={1} alignItems='center'>
           {/* Button to trigger the Electron directory picker */}
           {!isEditing && (
             <Button
@@ -145,6 +153,23 @@ export function DirectorySelectDisplay({
             >
               Save
             </Button>
+          )}
+          {/* Ready toggle — right-justified, only when directory is set */}
+          {!!directory && (
+            <FormControlLabel
+              label='Ready'
+              labelPlacement='start'
+              sx={{ color: '#333', margin: 0, marginLeft: 'auto' }}
+              control={
+                <Switch
+                  color='primary'
+                  checked={isActive && isReady}
+                  onChange={(_, checked) => onSetReady(checked)}
+                  size='small'
+                  disabled={!isActive}
+                />
+              }
+            />
           )}
         </Box>
       </Box>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/DirectorySelectDisplay.tsx
@@ -14,6 +14,7 @@ import WarningIcon from '@mui/icons-material/Warning'
 
 interface DirectorySelectDisplayProps {
   directory: string;
+  hasSavedDirectory: boolean;
   isEditing: boolean;
   isDifferent: boolean; // Positive flag for save
   isActive: boolean;
@@ -29,6 +30,7 @@ interface DirectorySelectDisplayProps {
 
 export function DirectorySelectDisplay({
   directory,
+  hasSavedDirectory,
   isEditing,
   isDifferent,
   isActive,
@@ -157,7 +159,7 @@ export function DirectorySelectDisplay({
             </Button>
           )}
           {/* Ready toggle — right-justified, only when directory is set */}
-          {showReadyToggle && !!directory && (
+          {showReadyToggle && hasSavedDirectory && (
             <FormControlLabel
               label='Ready'
               labelPlacement='start'

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/useDirectorySelect.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/useDirectorySelect.tsx
@@ -11,6 +11,7 @@ export function useDirectorySelect() {
   // Use the generic useEditableValue hook for managing value state
   const {
     editableValue,
+    originalValue,
     changeValue,
     saveEditedValue,
     startEdit,
@@ -47,6 +48,7 @@ export function useDirectorySelect() {
 
   return {
     editableValue,
+    originalValue,
     changeValue,
     saveEditedValue,
     startEdit,

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/useEditableValue.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/DirectorySelect/useEditableValue.tsx
@@ -62,6 +62,7 @@ export function useEditableValue({
 
   return {
     editableValue, // The current editable value
+    originalValue, // The last persisted value (from API or after save)
     changeValue, // Method to change the value
     saveEditedValue, // Method to save the changed value
     startEdit, // Method to start editing

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/MembersDisplay.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/MembersDisplay.tsx
@@ -87,20 +87,6 @@ export function MembersDisplay({
                   />
                 }
               />
-              <FormControlLabel
-                label='Ready'
-                labelPlacement='start'
-                sx={{ color: '#333', margin: 0 }}
-                control={
-                  <Switch
-                    color='primary'
-                    checked={itsMe.isActive && itsMe.isReady}
-                    onChange={(_, checked) => setMemberReady(itsMe.id, checked)}
-                    size='small'
-                    disabled={!itsMe.isActive}
-                  />
-                }
-              />
             </Box>
           </Box>
         </Box>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/VaultUserList.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/VaultUserList.tsx
@@ -28,7 +28,7 @@ interface VaultUserListProps {
 const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
   const { getHostedVaultList, leaderAddHostedVault } = useCentralApi()
   const [vaultUserList, setVaultUserList] = useState<HostedVault[]>([])
-  const [selectedVaultInfo, setSelectedVaultInfo] = useState<number>(0)
+  const [selectedVaultId, setSelectedVaultId] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
   const consortiumId = useParams<{ consortiumId: string }>().consortiumId as string
@@ -46,9 +46,7 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
       setError(null)
       const res = await getHostedVaultList({})
       setVaultUserList(res)
-      setSelectedVaultInfo((prev) =>
-        res.length === 0 ? 0 : Math.min(prev, res.length - 1),
-      )
+      setSelectedVaultId((prev) => prev ?? (res.length > 0 ? res[0].id : null))
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch vault users'
       setError(errorMessage)
@@ -76,22 +74,26 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
     [members],
   )
 
-  const vaultCompatibility = useMemo(
+  const compatibleVaults = useMemo(
     () =>
-      vaultUserList.map((vaultUser) => {
-        const allowsSelectedComputation =
-          !selectedComputation ||
-          (vaultUser.allowedComputations ?? []).some(
-            (computation) => computation.imageName === selectedComputation.imageName,
-          )
-
-        return {
+      vaultUserList
+        .filter(
+          (vaultUser) =>
+            !selectedComputation ||
+            (vaultUser.allowedComputations ?? []).some(
+              (computation) => computation.imageName === selectedComputation.imageName,
+            ),
+        )
+        .map((vaultUser) => ({
           vaultUser,
           alreadyMember: existingMemberIds.has(vaultUser.id),
-          allowsSelectedComputation,
-        }
-      }),
+        })),
     [existingMemberIds, selectedComputation, vaultUserList],
+  )
+
+  const selectedVault = useMemo(
+    () => vaultUserList.find((v) => v.id === selectedVaultId) ?? compatibleVaults[0]?.vaultUser ?? null,
+    [selectedVaultId, vaultUserList, compatibleVaults],
   )
 
   if (loading) {
@@ -143,99 +145,82 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
         >
           {selectedComputation && (
             <Alert severity='info' sx={{ mb: 2 }}>
-              Current computation: {selectedComputation.title}. Only vaults that
-              allow it can be added.
+              Showing vaults compatible with: {selectedComputation.title}
             </Alert>
           )}
-          {vaultUserList.length === 0 ? (
+          {compatibleVaults.length === 0 ? (
             <Box sx={{ p: 2, textAlign: 'center' }}>
               <Typography variant='body1' color='text.secondary'>
-                No vault users found
+                No compatible vault users found
               </Typography>
             </Box>
           ) : (
             <List>
-              {vaultCompatibility.map(
-                ({ vaultUser, alreadyMember, allowsSelectedComputation }, index) => {
-                  const { id } = vaultUser
-                  const addDisabled = alreadyMember || !allowsSelectedComputation
+              {compatibleVaults.map(({ vaultUser, alreadyMember }) => {
+                const { id } = vaultUser
 
-                  return (
-                    <React.Fragment key={id}>
-                      <ListItem
+                return (
+                  <React.Fragment key={id}>
+                    <ListItem
+                      sx={{
+                        padding: '1rem 0',
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        gap: 2,
+                      }}
+                    >
+                      <ListItemText
+                        primary={vaultUser.name}
+                        secondary={vaultUser.datasetKey}
+                        primaryTypographyProps={{
+                          fontWeight: 'bold',
+                          sx: {
+                            overflowWrap: 'anywhere',
+                            pr: 1,
+                          },
+                        }}
+                        secondaryTypographyProps={{
+                          sx: {
+                            overflowWrap: 'anywhere',
+                            pr: 1,
+                          },
+                        }}
+                        sx={{ flex: '1 1 auto', minWidth: 0, my: 0 }}
+                      />
+                      <Box
                         sx={{
-                          padding: '1rem 0',
                           display: 'flex',
-                          alignItems: 'flex-start',
-                          gap: 2,
+                          flexDirection: 'column',
+                          gap: '0.5rem',
+                          flex: '0 0 128px',
+                          alignItems: 'stretch',
                         }}
                       >
-                        <ListItemText
-                          primary={vaultUser.name}
-                          secondary={vaultUser.datasetKey}
-                          primaryTypographyProps={{
-                            fontWeight: 'bold',
-                            sx: {
-                              overflowWrap: 'anywhere',
-                              pr: 1,
-                            },
-                          }}
-                          secondaryTypographyProps={{
-                            sx: {
-                              overflowWrap: 'anywhere',
-                              pr: 1,
-                            },
-                          }}
-                          sx={{ flex: '1 1 auto', minWidth: 0, my: 0 }}
-                        />
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: '0.5rem',
-                            flex: '0 0 128px',
-                            alignItems: 'stretch',
-                          }}
+                        <Button
+                          variant='outlined'
+                          color='primary'
+                          size='small'
+                          onClick={() => setSelectedVaultId(id)}
+                          sx={{ minWidth: 0 }}
                         >
-                          <Button
-                            variant='outlined'
-                            color='primary'
-                            size='small'
-                            onClick={() => setSelectedVaultInfo(index)}
-                            sx={{ minWidth: 0 }}
-                          >
-                            Info
-                          </Button>
-                          <Button
-                            variant='contained'
-                            color='primary'
-                            size='small'
-                            disabled={addDisabled}
-                            onClick={() => handleAdd(id)}
-                            sx={{ minWidth: 0 }}
-                          >
-                            {alreadyMember ? 'Added' : 'Add'}
-                          </Button>
-                          {!allowsSelectedComputation && (
-                            <Typography
-                              variant='caption'
-                              color='error'
-                              sx={{
-                                lineHeight: 1.2,
-                                overflowWrap: 'anywhere',
-                                textAlign: 'center',
-                              }}
-                            >
-                              Not allowed for current computation
-                            </Typography>
-                          )}
-                        </Box>
-                      </ListItem>
-                      <Divider component='li' />
-                    </React.Fragment>
-                  )
-                },
-              )}
+                          Info
+                        </Button>
+                        <Button
+                          variant='contained'
+                          color='primary'
+                          size='small'
+                          disabled={alreadyMember}
+                          onClick={() => handleAdd(id)}
+                          sx={{ minWidth: 0 }}
+                        >
+                          {alreadyMember ? 'Added' : 'Add'}
+                        </Button>
+                      </Box>
+                    </ListItem>
+                    <Divider component='li' />
+                  </React.Fragment>
+                )
+              })}
             </List>
           )}
         </Box>
@@ -251,7 +236,7 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
             variant='subtitle2'
             sx={{ color: 'text.primary', overflowWrap: 'anywhere' }}
           >
-            {vaultUserList[selectedVaultInfo]?.datasetKey}
+            {selectedVault?.datasetKey}
           </Typography>
           <Typography
             variant='h4'
@@ -262,7 +247,7 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
               overflowWrap: 'anywhere',
             }}
           >
-            {vaultUserList[selectedVaultInfo]?.name}
+            {selectedVault?.name}
           </Typography>
           <Box
             sx={{
@@ -272,8 +257,8 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
               marginBottom: '1rem',
             }}
           >
-            {(vaultUserList[selectedVaultInfo]?.allowedComputations ?? []).length ? (
-              (vaultUserList[selectedVaultInfo]?.allowedComputations ?? []).map((computation) => (
+            {(selectedVault?.allowedComputations ?? []).length ? (
+              (selectedVault?.allowedComputations ?? []).map((computation) => (
                 <Chip
                   key={computation.id}
                   label={computation.title}
@@ -331,7 +316,7 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
               components={markdownComponents}
               remarkPlugins={[remarkGfm]}
             >
-              {vaultUserList[selectedVaultInfo]?.description ?? ''}
+              {selectedVault?.description ?? ''}
             </ReactMarkdown>
           </Box>
         </Box>

--- a/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/VaultUserList.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumDetails/Members/VaultUserList.tsx
@@ -46,7 +46,6 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
       setError(null)
       const res = await getHostedVaultList({})
       setVaultUserList(res)
-      setSelectedVaultId((prev) => prev ?? (res.length > 0 ? res[0].id : null))
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch vault users'
       setError(errorMessage)
@@ -92,8 +91,10 @@ const VaultUserList: React.FC<VaultUserListProps> = ({ onClose }) => {
   )
 
   const selectedVault = useMemo(
-    () => vaultUserList.find((v) => v.id === selectedVaultId) ?? compatibleVaults[0]?.vaultUser ?? null,
-    [selectedVaultId, vaultUserList, compatibleVaults],
+    () => compatibleVaults.find(({ vaultUser }) =>
+      vaultUser.id === selectedVaultId,
+    )?.vaultUser ?? compatibleVaults[0]?.vaultUser ?? null,
+    [selectedVaultId, compatibleVaults],
   )
 
   if (loading) {

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/ConsortiumWizard.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/ConsortiumWizard.tsx
@@ -6,6 +6,7 @@ import StepSetParameters from './steps/StepSetParameters'
 import StepSetLocalParameters from './steps/StepSetLocalParameters'
 import StepSelectData from './steps/StepSelectData'
 import StepAddNotes from './steps/StepAddNotes'
+import StepAddVaultUser from './steps/StepAddVaultUser'
 import StepDownloadImage from './steps/StepDownloadImage'
 import StepSetReady from './steps/StepSetReady'
 import StepViewRequirements from './steps/StepViewRequirements'
@@ -25,10 +26,17 @@ const ConsortiumWizard = () => {
   const [step, setStep] = useState<number>(0)
   const [steps, setSteps] = useState<StepsType[]>([])
   const [isReady, setIsReady] = useState<boolean>(false)
+  const [imageDownloaded, setImageDownloaded] = useState<boolean>(false)
+  const [requirementsAcknowledged, setRequirementsAcknowledged] = useState<boolean>(false)
+  const [directorySet, setDirectorySet] = useState<boolean>(false)
   const navigate = useNavigate()
 
   const { consortiumId } = useParams<{ consortiumId: string }>()
   const { data, isLeader } = useConsortiumDetailsContext()
+  const parametersSet = (() => {
+    const p = data?.studyConfiguration?.computationParameters?.trim()
+    return !!p && p !== '{}'
+  })()
   const { userId } = useUserState()
   const { readyMembers } = data
 
@@ -48,14 +56,14 @@ const ConsortiumWizard = () => {
   ]
 
   const leaderSteps: StepsType[] = [
-    { label: 'Select Computation', path: 'step-select-computation' },
-    { label: 'Download Computation Image', path: 'step-download-image' },
+    { label: 'Select Computation & Download Image', path: 'step-select-computation' },
+    { label: 'Add Vault User (Optional)', path: 'step-add-vault-user' },
     { label: 'Set Parameters', path: 'step-set-parameters' },
     { label: 'Select Data Directory', path: 'step-select-data' },
     ...(supportsLocal
       ? [{ label: 'Set Local Parameters', path: 'step-set-local-parameters' } as StepsType]
       : []),
-    { label: 'Add Leader Notes', path: 'step-add-notes' },
+    { label: 'Add Leader Notes (Optional)', path: 'step-add-notes' },
     { label: 'Set Ready Status', path: 'step-set-ready' },
   ]
 
@@ -137,17 +145,18 @@ const ConsortiumWizard = () => {
           {/* Step Routes */}
           <Box style={{ margin: '0 1rem 2rem' }}>
             <Routes>
-              <Route path='step-select-computation' element={<StepSelectComputation />} />
+              <Route path='step-select-computation' element={<StepSelectComputation onImageDownloaded={() => setImageDownloaded(true)} />} />
+              <Route path='step-add-vault-user' element={<StepAddVaultUser />} />
               <Route path='step-set-parameters' element={<StepSetParameters />} />
-              <Route path='step-select-data' element={<StepSelectData />} />
+              <Route path='step-select-data' element={<StepSelectData onDirectorySet={setDirectorySet} />} />
               {/* Only mount the Local Parameters route if supported */}
               {supportsLocal && (
                 <Route path='step-set-local-parameters' element={<StepSetLocalParameters />} />
               )}
-              <Route path='step-download-image' element={<StepDownloadImage />} />
+              <Route path='step-download-image' element={<StepDownloadImage onImageDownloaded={() => setImageDownloaded(true)} />} />
               <Route path='step-add-notes' element={<StepAddNotes />} />
               <Route path='step-set-ready' element={<StepSetReady />} />
-              <Route path='step-view-requirements' element={<StepViewRequirements />} />
+              <Route path='step-view-requirements' element={<StepViewRequirements onAcknowledged={setRequirementsAcknowledged} />} />
             </Routes>
           </Box>
 
@@ -173,12 +182,20 @@ const ConsortiumWizard = () => {
                 Go Back A Step
               </Button>
             )}
-            {(isReady || step === steps.length - 1) && (
+            {isReady && (
               <Button variant='outlined' color='primary' onClick={handleNavigateToConsortiumDetails}>
                 View Consortium Details
               </Button>
             )}
-            {step !== steps.length - 1 && (
+            {step !== steps.length - 1 && (() => {
+              const path = steps[step]?.path
+              if (path === 'step-view-requirements') return requirementsAcknowledged
+              if (path === 'step-select-computation') return imageDownloaded
+              if (path === 'step-download-image') return imageDownloaded
+              if (path === 'step-set-parameters') return parametersSet
+              if (path === 'step-select-data') return directorySet
+              return true
+            })() && (
               <Button
                 variant='contained'
                 color='primary'

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/ConsortiumWizard.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/ConsortiumWizard.tsx
@@ -43,6 +43,8 @@ const ConsortiumWizard = () => {
   // Support flag straight from computation
   const supportsLocal =
     !!data?.studyConfiguration?.computation?.hasLocalParameters
+  const selectedComputationImage =
+    data?.studyConfiguration?.computation?.imageName
 
   // Build step lists based on role AND supportsLocal
   const memberSteps: StepsType[] = [
@@ -82,6 +84,10 @@ const ConsortiumWizard = () => {
     const userIsReady = readyMembers.some((user) => user.id === userId)
     setIsReady(userIsReady)
   }, [readyMembers, userId])
+
+  useEffect(() => {
+    setImageDownloaded(false)
+  }, [selectedComputationImage])
 
   const handleNext = () => {
     if (steps.length > 0 && step < steps.length - 1) {
@@ -145,7 +151,14 @@ const ConsortiumWizard = () => {
           {/* Step Routes */}
           <Box style={{ margin: '0 1rem 2rem' }}>
             <Routes>
-              <Route path='step-select-computation' element={<StepSelectComputation onImageDownloaded={() => setImageDownloaded(true)} />} />
+              <Route
+                path='step-select-computation'
+                element={(
+                  <StepSelectComputation
+                    onImageDownloaded={setImageDownloaded}
+                  />
+                )}
+              />
               <Route path='step-add-vault-user' element={<StepAddVaultUser />} />
               <Route path='step-set-parameters' element={<StepSetParameters />} />
               <Route path='step-select-data' element={<StepSelectData onDirectorySet={setDirectorySet} />} />
@@ -153,10 +166,20 @@ const ConsortiumWizard = () => {
               {supportsLocal && (
                 <Route path='step-set-local-parameters' element={<StepSetLocalParameters />} />
               )}
-              <Route path='step-download-image' element={<StepDownloadImage onImageDownloaded={() => setImageDownloaded(true)} />} />
+              <Route
+                path='step-download-image'
+                element={<StepDownloadImage onImageDownloaded={setImageDownloaded} />}
+              />
               <Route path='step-add-notes' element={<StepAddNotes />} />
               <Route path='step-set-ready' element={<StepSetReady />} />
-              <Route path='step-view-requirements' element={<StepViewRequirements onAcknowledged={setRequirementsAcknowledged} />} />
+              <Route
+                path='step-view-requirements'
+                element={(
+                  <StepViewRequirements
+                    onAcknowledged={setRequirementsAcknowledged}
+                  />
+                )}
+              />
             </Routes>
           </Box>
 

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepAddVaultUser.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepAddVaultUser.tsx
@@ -1,0 +1,5 @@
+import VaultUserList from '../../ConsortiumDetails/Members/VaultUserList'
+
+export default function StepAddVaultUser() {
+  return <VaultUserList onClose={() => {}} />
+}

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepDownloadImage.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepDownloadImage.tsx
@@ -1,65 +1,18 @@
 import { Box } from '@mui/material'
 import Computation from '../../ConsortiumDetails/Computation/Computation'
 import { useConsortiumDetailsContext } from '../../ConsortiumDetails/ConsortiumDetailsContext'
-import ArrowDown from '../../../assets/arrow-down.png'
 
-export default function StepDownloadImage() {
+export default function StepDownloadImage({ onImageDownloaded }: { onImageDownloaded?: () => void }) {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const selectedComputation = consortiumDetails?.studyConfiguration?.computation
 
   return (
-    <Box
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        width: '100%',
-        alignItems: 'top',
-      }}
-    >
-      <Box
-        style={{
-          maxWidth: '400px',
-          border: '1px solid #eee',
-          marginBottom: '1rem',
-        }}
-      >
-        <Computation computation={selectedComputation} />
-      </Box>
-      <Box
-        style={{
-          maxWidth: '400px',
-          marginBottom: '1rem',
-          padding: '1rem',
-          display: 'flex',
-          flexDirection: 'row',
-          width: '100%',
-          alignItems: 'center',
-        }}
-      >
-        <div style={{ position: 'relative', width: '225px', height: '100px' }}>
-          <img
-            src={ArrowDown}
-            style={{
-              width: '100px',
-              rotate: '20deg',
-              position: 'absolute',
-              top: '0',
-              left: '-1rem',
-            }}
-          />
-        </div>
-        <div style={{ fontWeight: 'bold' }}>
-          <h3 style={{ color: 'red' }}>To download the Computation Image:</h3>
-          <ol>
-            <li>
-              Press this icon to copy the "Image Download" command.
-            </li>
-            <li>
-              Open your system's terminal, paste command in and press enter.
-            </li>
-          </ol>
-        </div>
-      </Box>
+    <Box style={{ maxWidth: '400px', border: '1px solid #eee', marginBottom: '1rem' }}>
+      <Computation
+        computation={selectedComputation}
+        showDownloadInstructions={true}
+        onImageDownloaded={onImageDownloaded}
+      />
     </Box>
   )
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepDownloadImage.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepDownloadImage.tsx
@@ -2,7 +2,11 @@ import { Box } from '@mui/material'
 import Computation from '../../ConsortiumDetails/Computation/Computation'
 import { useConsortiumDetailsContext } from '../../ConsortiumDetails/ConsortiumDetailsContext'
 
-export default function StepDownloadImage({ onImageDownloaded }: { onImageDownloaded?: () => void }) {
+export default function StepDownloadImage({
+  onImageDownloaded,
+}: {
+  onImageDownloaded?: (downloaded: boolean) => void;
+}) {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const selectedComputation = consortiumDetails?.studyConfiguration?.computation
 
@@ -10,7 +14,7 @@ export default function StepDownloadImage({ onImageDownloaded }: { onImageDownlo
     <Box style={{ maxWidth: '400px', border: '1px solid #eee', marginBottom: '1rem' }}>
       <Computation
         computation={selectedComputation}
-        showDownloadInstructions={true}
+        showDownloadInstructions
         onImageDownloaded={onImageDownloaded}
       />
     </Box>

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectComputation.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectComputation.tsx
@@ -2,19 +2,17 @@ import { Box } from '@mui/material'
 import Computation from '../../ConsortiumDetails/Computation/Computation'
 import { useConsortiumDetailsContext } from '../../ConsortiumDetails/ConsortiumDetailsContext'
 
-export default function StepSelectComputation() {
+export default function StepSelectComputation({ onImageDownloaded }: { onImageDownloaded?: () => void }) {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const selectedComputation = consortiumDetails?.studyConfiguration?.computation
 
   return (
-    <Box
-      style={{
-        maxWidth: '400px',
-        border: '1px solid #eee',
-        marginBottom: '1rem',
-      }}
-    >
-      <Computation computation={selectedComputation} />
+    <Box style={{ maxWidth: '400px', border: '1px solid #eee', marginBottom: '1rem' }}>
+      <Computation
+        computation={selectedComputation}
+        showDownloadInstructions={!!selectedComputation}
+        onImageDownloaded={onImageDownloaded}
+      />
     </Box>
   )
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectComputation.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectComputation.tsx
@@ -2,7 +2,11 @@ import { Box } from '@mui/material'
 import Computation from '../../ConsortiumDetails/Computation/Computation'
 import { useConsortiumDetailsContext } from '../../ConsortiumDetails/ConsortiumDetailsContext'
 
-export default function StepSelectComputation({ onImageDownloaded }: { onImageDownloaded?: () => void }) {
+export default function StepSelectComputation({
+  onImageDownloaded,
+}: {
+  onImageDownloaded?: (downloaded: boolean) => void;
+}) {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const selectedComputation = consortiumDetails?.studyConfiguration?.computation
 

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectData.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepSelectData.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/material'
 import DirectorySelect from '../../ConsortiumDetails/DirectorySelect/DirectorySelect'
 
-export default function StepSelectData() {
+export default function StepSelectData({ onDirectorySet }: { onDirectorySet?: (isSet: boolean) => void }) {
   return (
     <Box
       style={{
@@ -9,7 +9,7 @@ export default function StepSelectData() {
         border: '1px solid #eee',
       }}
     >
-      <DirectorySelect />
+      <DirectorySelect showReadyToggle={false} onDirectorySet={onDirectorySet} />
     </Box>
   )
 }

--- a/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepViewRequirements.tsx
+++ b/desktopApp/reactApp/src/pages/ConsortiumWizard/steps/StepViewRequirements.tsx
@@ -1,11 +1,19 @@
-import { Box, Grid, Typography } from '@mui/material'
+import { useState } from 'react'
+import { Box, Checkbox, FormControlLabel, Grid, Typography } from '@mui/material'
 import ConsortiumLeaderNotes from '../../ConsortiumDetails/ConsortiumLeaderNotes/ConsortiumLeaderNotes'
 import ComputationDisplay from '../../ConsortiumDetails/ComputationDisplay/ComputationDisplay'
 import { useConsortiumDetailsContext } from '../../ConsortiumDetails/ConsortiumDetailsContext'
 
-export default function StepViewRequirements() {
+export default function StepViewRequirements({ onAcknowledged }: { onAcknowledged?: (acknowledged: boolean) => void }) {
   const { data: consortiumDetails } = useConsortiumDetailsContext()
   const consortiumLeaderNotes = consortiumDetails?.studyConfiguration?.consortiumLeaderNotes
+  const hasLeaderNotes = !!consortiumLeaderNotes?.trim()
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const handleAcknowledge = (checked: boolean) => {
+    setAcknowledged(checked)
+    onAcknowledged?.(checked)
+  }
 
   return (
     <>
@@ -15,7 +23,7 @@ export default function StepViewRequirements() {
       </Box>
       <Box
         sx={{
-          height: 'calc(100vh - 31rem)',  // Limit height to keep within view
+          height: 'calc(100vh - 33rem)',  // Limit height to keep within view
           overflow: 'hidden',  // Allow vertical scrolling if content exceeds
           padding: 1,
           boxSizing: 'border-box',
@@ -29,7 +37,7 @@ export default function StepViewRequirements() {
               Computation Notes
             </Typography>
             <Box sx={{
-              height: 'calc(100vh - 26rem)',  // Limit height to keep within view
+              height: 'calc(100vh - 28rem)',  // Limit height to keep within view
               overflowY: 'scroll',  // Allow vertical scrolling if content exceeds
               padding: '0 1rem 6rem',
               boxSizing: 'border-box',
@@ -41,7 +49,7 @@ export default function StepViewRequirements() {
           {consortiumLeaderNotes && (
             <Grid item xs={6}>
               <Box sx={{
-                height: 'calc(100vh - 26rem)',  // Limit height to keep within view
+                height: 'calc(100vh - 28rem)',  // Limit height to keep within view
                 overflowY: 'scroll',  // Allow vertical scrolling if content exceeds
                 padding: '0 1rem 6rem',
                 boxSizing: 'border-box',
@@ -55,6 +63,18 @@ export default function StepViewRequirements() {
             </Grid>
           )}
         </Grid>
+      </Box>
+      <Box display='flex' justifyContent='flex-end' mt={1}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={acknowledged}
+              onChange={(_, checked) => handleAcknowledge(checked)}
+              size='small'
+            />
+          }
+          label={`I've read and understand the Computation${hasLeaderNotes ? ' and Leader' : ''} Notes`}
+        />
       </Box>
     </>
   )

--- a/desktopApp/reactApp/src/pages/LoginPage/Login/Login.tsx
+++ b/desktopApp/reactApp/src/pages/LoginPage/Login/Login.tsx
@@ -86,6 +86,10 @@ export function Login() {
             onChange={(e) => setKeepLoggedIn(e.target.checked)}
             disabled={loading}
             size='small'
+            sx={{
+              color: 'white',
+              '&.Mui-checked': { color: 'white' },
+            }}
           />
         )}
         label='Keep me logged in'

--- a/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
+++ b/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import axios from 'axios'
-import { useUserState } from '../../contexts/UserStateContext'
 
 export interface FileInfo {
   name: string;
@@ -9,11 +8,10 @@ export interface FileInfo {
   size: number;
   isDirectory: boolean;
   lastModified: string;
-  url: string; // This is relative: consortiumId/runId/participantId/...
+  url: string; // This is relative: consortiumId/runId/...
 }
 
 export function useRunResults() {
-  const { userId } = useUserState()
   const {
     consortiumId,
     runId,
@@ -79,11 +77,11 @@ export function useRunResults() {
   }, [])
 
   useEffect(() => {
-    if (!edgeClientRunResultsUrl || !consortiumId || !runId || !userId) return
+    if (!edgeClientRunResultsUrl || !consortiumId || !runId) return
 
     const fetchResultsFilesList = async () => {
       try {
-        const basePath = `${consortiumId}/${runId}/${userId}`
+        const basePath = `${consortiumId}/${runId}`
         const files = await fetchRecursive(basePath)
 
         const indexFile = files.find((file) =>
@@ -106,7 +104,7 @@ export function useRunResults() {
     }
 
     fetchResultsFilesList()
-  }, [edgeClientRunResultsUrl, consortiumId, runId, userId, frameSrc])
+  }, [edgeClientRunResultsUrl, consortiumId, runId, frameSrc])
 
   const handleHideFiles = () => {
     setFilesPanelWidth({ sm: 0, md: 0 })

--- a/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
+++ b/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import axios from 'axios'
+import { useUserState } from '../../contexts/UserStateContext'
 
 export interface FileInfo {
   name: string;
@@ -8,10 +9,11 @@ export interface FileInfo {
   size: number;
   isDirectory: boolean;
   lastModified: string;
-  url: string; // This is relative: consortiumId/runId/...
+  url: string; // This is relative: consortiumId/runId/participantId/...
 }
 
 export function useRunResults() {
+  const { userId } = useUserState()
   const {
     consortiumId,
     runId,
@@ -77,11 +79,11 @@ export function useRunResults() {
   }, [])
 
   useEffect(() => {
-    if (!edgeClientRunResultsUrl || !consortiumId || !runId) return
+    if (!edgeClientRunResultsUrl || !consortiumId || !runId || !userId) return
 
     const fetchResultsFilesList = async () => {
       try {
-        const basePath = `${consortiumId}/${runId}`
+        const basePath = `${consortiumId}/${runId}/${userId}`
         const files = await fetchRecursive(basePath)
 
         const indexFile = files.find((file) =>
@@ -104,7 +106,7 @@ export function useRunResults() {
     }
 
     fetchResultsFilesList()
-  }, [edgeClientRunResultsUrl, consortiumId, runId, frameSrc])
+  }, [edgeClientRunResultsUrl, consortiumId, runId, userId, frameSrc])
 
   const handleHideFiles = () => {
     setFilesPanelWidth({ sm: 0, md: 0 })


### PR DESCRIPTION
## Summary

This branch delivers a series of UI improvements across the Consortium Setup Wizard,
the Consortium Details page, and the login screen.

### Consortium Setup Wizard — Leader Flow
- **Combined Step 1**: Computation selection and image download are now a single step
  ("Select Computation & Download Image"). Download instructions appear inline once a
  computation is selected, and "Go To Next Step" is gated until the Docker/Singularity
  image is confirmed downloaded.
- **New Step 2 — Add Vault User (Optional)**: Leaders can optionally associate a vault
  user before continuing.
- **Step gating**: Each step enforces prerequisites before "Go To Next Step" appears:
  - *Select Computation & Download Image*: image must be downloaded
  - *Set Parameters*: parameters must be set (non-empty, not `{}`)
  - *Select Data Directory*: directory must be saved
- **"View Consortium Details"** is hidden until the leader's Ready status is true.
- Leader Notes step is labeled "(Optional)".

### Consortium Setup Wizard — Member Flow
- **Step gating** mirrors the leader flow for comparable steps:
  - *View Consortium Requirements*: acknowledgement checkbox must be checked
  - *Select Data Directory*: directory must be saved
  - *Download Computation Image*: image must be confirmed downloaded
- **View Consortium Requirements**: added an acknowledgement checkbox ("I've read and
  understand the Computation and Leader Notes") — "and Leader" only appears when leader
  notes are set.
- **Download Computation Image** step now matches the leader's download step layout,
  with inline instructions and the same Docker/Singularity detection.

### Consortium Details Page
- **Ready toggle** moved from the Members section into the Data Directory row,
  right-justified, and only visible when a directory path has been saved.
- **Computation Notes** column is expandable on desktop (md+): clicking the expand icon
  merges columns 1 and 2 into a single panel and gives the notes column full width.
- **Leader Notes** are hidden from non-leader members when the notes field is empty.

### Other
- **Vault User List**: only compatible vaults (those that support the selected
  computation) are shown — incompatible vaults are filtered out entirely.
- **Login checkbox**: updated to a white-outlined style for better visibility on the
  dark login background.

## Test Plan
- [ ] Leader wizard: verify each step gate blocks "Go To Next Step" until its condition
      is met
- [ ] Leader wizard: confirm "Add Vault User" step is skippable (Optional label, no gate)
- [ ] Member wizard: verify acknowledgement checkbox gates Step 1
- [ ] Member wizard: verify directory save gates Step 2 and image download gates Step 3
- [ ] Consortium Details: Ready toggle appears only after a directory is saved
- [ ] Computation Notes expand/collapse works on desktop; hidden on mobile
- [ ] Leader Notes hidden for members when field is blank
- [ ] Vault user list only shows compatible vaults
- [ ] Login checkbox renders with white outline when unchecked
