### PR TITLE
UI: Terminal bug

### DIFF
--- a/centralApi/src/graphql/resolvers.ts
+++ b/centralApi/src/graphql/resolvers.ts
@@ -60,8 +60,28 @@ const toObjectIdString = (value: unknown): string | null => {
 }
 
 const resend = new Resend(RESEND_API_KEY)
+const RESEND_DOMAIN_ID = '8de32797-98b9-4fc9-a1fc-06b03f5248e0'
 const INVITE_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+let resendFromPromise: Promise<string> | null = null
+
+const getResendFrom = (): Promise<string> => {
+  resendFromPromise ??= resend.domains
+    .get(RESEND_DOMAIN_ID)
+    .then(({ data, error }) => {
+      if (error) {
+        throw new Error(`Failed to retrieve Resend domain: ${error.message}`)
+      }
+
+      if (!data?.name) {
+        throw new Error('Failed to retrieve Resend domain: missing domain name')
+      }
+
+      return `NeuroFLAME <no-reply@${data.name}>`
+    })
+
+  return resendFromPromise
+}
 
 const mapAllowedComputations = (
   computations: any[] | undefined,
@@ -405,12 +425,16 @@ const sendInviteEmail = async ({
   const html = `${leaderName} invites you to join ${consortiumTitle} on NeuroFLAME. <br/>
       Please click this <a href="${getInviteUrl(token)}">link</a> to join.`
 
-  await resend.emails.send({
-    to: email,
-    from: 'no-reply@coinstac.org',
+  const { error } = await resend.emails.send({
+    from: await getResendFrom(),
+    to: [email],
     subject: `Invitation to join ${consortiumTitle}`,
     html,
   })
+
+  if (error) {
+    throw new Error(`Failed to send invite email: ${error.message}`)
+  }
 }
 
 export default {
@@ -1223,8 +1247,8 @@ export default {
 
       const email = user.username
       const msg = {
-        to: email,
-        from: 'no-reply@coinstac.org',
+        from: await getResendFrom(),
+        to: [email],
         subject: 'Password Reset Request',
         html: `We received your password reset request. <br/>
             Please use this token for password reset. <br/>
@@ -1233,7 +1257,10 @@ export default {
       }
 
       try {
-        await resend.emails.send(msg)
+        const { error } = await resend.emails.send(msg)
+        if (error) {
+          throw new Error(error.message)
+        }
       } catch (error: any) {
         throw new Error(`Failed to send email: ${error.message}`)
       }

--- a/centralApi/src/graphql/resolvers.ts
+++ b/centralApi/src/graphql/resolvers.ts
@@ -61,28 +61,9 @@ const toObjectIdString = (value: unknown): string | null => {
 }
 
 const resend = new Resend(RESEND_API_KEY)
-const RESEND_DOMAIN_ID = '8de32797-98b9-4fc9-a1fc-06b03f5248e0'
+const RESEND_FROM = 'NeuroFLAME <no-reply@em5561.coinstac.org>'
 const INVITE_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-let resendFromPromise: Promise<string> | null = null
-
-const getResendFrom = (): Promise<string> => {
-  resendFromPromise ??= resend.domains
-    .get(RESEND_DOMAIN_ID)
-    .then(({ data, error }) => {
-      if (error) {
-        throw new Error(`Failed to retrieve Resend domain: ${error.message}`)
-      }
-
-      if (!data?.name) {
-        throw new Error('Failed to retrieve Resend domain: missing domain name')
-      }
-
-      return `NeuroFLAME <no-reply@${data.name}>`
-    })
-
-  return resendFromPromise
-}
 
 const mapAllowedComputations = (
   computations: any[] | undefined,
@@ -427,7 +408,7 @@ const sendInviteEmail = async ({
       Please click this <a href="${getInviteUrl(token)}">link</a> to join.`
 
   const { error } = await resend.emails.send({
-    from: await getResendFrom(),
+    from: RESEND_FROM,
     to: [email],
     subject: `Invitation to join ${consortiumTitle}`,
     html,
@@ -1251,7 +1232,7 @@ export default {
 
       const email = user.username
       const msg = {
-        from: await getResendFrom(),
+        from: RESEND_FROM,
         to: [email],
         subject: 'Password Reset Request',
         html: `We received your password reset request. <br/>

--- a/desktopApp/electronApp/src/main.ts
+++ b/desktopApp/electronApp/src/main.ts
@@ -25,6 +25,8 @@ app.setName('NeuroFLAME')
 
 let mainWindow: BrowserWindow | null = null
 let terminalProcess: TerminalProcess | null = null
+let appInitializationPromise: Promise<void> | null = null
+let windowCreationPromise: Promise<void> | null = null
 
 // ---- Helpers: shell + env normalization ------------------------------------
 
@@ -181,94 +183,122 @@ async function getEdgeClientLogLines(options?: { maxBytes?: number; maxLines?: n
 
 // ---- App bootstrap ----------------------------------------------------------
 
-async function appOnReady(): Promise<void> {
-  try {
-    const config = await initializeConfig()
-    logToPath(config.logPath as string)
-    if (config.startEdgeClientOnLaunch) {
-      startEdgeFederatedClient(config.edgeClientConfig)
-    }
-  } catch (error) {
-    showInitializationError(error as Error)
+function initializeApp(): Promise<void> {
+  if (!appInitializationPromise) {
+    appInitializationPromise = (async () => {
+      try {
+        const config = await initializeConfig()
+        logToPath(config.logPath as string)
+        if (config.startEdgeClientOnLaunch) {
+          startEdgeFederatedClient(config.edgeClientConfig)
+        }
+      } catch (error) {
+        showInitializationError(error as Error)
+      }
+    })()
   }
 
-  mainWindow = await createMainWindow()
-
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    const parsedUrl = new URL(url)
-
-    if (parsedUrl.pathname === '/nii-viewer') {
-      const niiUrl = parsedUrl.searchParams.get('url')
-      if (niiUrl && mainWindow) {
-        mainWindow.webContents.executeJavaScript(
-          `window.dispatchEvent(new MessageEvent('message', { data: { type: 'view-nifti', url: ${JSON.stringify(niiUrl)} } }))`
-        ).catch(() => {})
-      }
-      return { action: 'deny' }
-    }
-
-    if (parsedUrl.pathname.includes('/zip/')) {
-      mainWindow?.webContents.downloadURL(url)
-      return { action: 'deny' }
-    }
-
-    const openInSelf = parsedUrl.searchParams.get('window') === 'self'
-    if (openInSelf) {
-      mainWindow?.loadURL(url)
-      return { action: 'deny' }
-    }
-    return { action: 'allow' }
-  })
-
-  // ---- Terminal IPC ----------------------------------
-
-  ipcMain.handle('spawnTerminal', () => {
-    // Clean up any previous instance
-    if (terminalProcess && terminalProcess.isRunning()) {
-      terminalProcess.kill()
-    }
-
-    const { shell, args } = resolveShellAndArgs()
-    const { env, home } = baseEnv()
-
-    terminalProcess = new TerminalProcess(shell, args, home, env)
-
-    // Wire process events once (don’t add listeners on every keystroke)
-    terminalProcess.process.stdout.on('data', (chunk: Buffer) => {
-      mainWindow?.webContents.send('terminalOutput', chunk.toString())
-    })
-
-    terminalProcess.process.stderr.on('data', (chunk: Buffer) => {
-      mainWindow?.webContents.send('terminalOutput', chunk.toString())
-    })
-
-    terminalProcess.process.on('error', (err: Error) => {
-      mainWindow?.webContents.send('terminalOutput', `Spawn error: ${err.message}`)
-    })
-
-    terminalProcess.process.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
-      mainWindow?.webContents.send(
-        'terminalOutput',
-        `\n[terminal exited: code=${code ?? 'null'} signal=${signal ?? 'null'}]`,
-      )
-    })
-
-    return { status: 'terminalStarted', pid: terminalProcess.process.pid }
-  })
-
-  ipcMain.on('terminalInput', (_event, input: string) => {
-    if (!terminalProcess || !terminalProcess.isRunning()) return
-    // Append newline unless you intend to send raw control sequences
-    terminalProcess.send(input.endsWith('\n') ? input : input + '\n')
-  })
-
-  mainWindow.on('closed', () => {
-    logger.info('Main window closed')
-    mainWindow = null
-  })
+  return appInitializationPromise
 }
 
-app.on('ready', appOnReady)
+async function openMainWindow(): Promise<void> {
+  if (mainWindow) return
+
+  if (!windowCreationPromise) {
+    windowCreationPromise = (async () => {
+      const window = await createMainWindow()
+      mainWindow = window
+
+      window.webContents.setWindowOpenHandler(({ url }) => {
+        const parsedUrl = new URL(url)
+
+        if (parsedUrl.pathname === '/nii-viewer') {
+          const niiUrl = parsedUrl.searchParams.get('url')
+          if (niiUrl) {
+            window.webContents.executeJavaScript(
+              `window.dispatchEvent(new MessageEvent('message', { data: { type: 'view-nifti', url: ${JSON.stringify(niiUrl)} } }))`
+            ).catch(() => {})
+          }
+          return { action: 'deny' }
+        }
+
+        if (parsedUrl.pathname.includes('/zip/')) {
+          window.webContents.downloadURL(url)
+          return { action: 'deny' }
+        }
+
+        const openInSelf = parsedUrl.searchParams.get('window') === 'self'
+        if (openInSelf) {
+          window.loadURL(url)
+          return { action: 'deny' }
+        }
+        return { action: 'allow' }
+      })
+
+      window.on('closed', () => {
+        logger.info('Main window closed')
+        if (mainWindow === window) mainWindow = null
+      })
+    })()
+
+    windowCreationPromise.finally(() => {
+      windowCreationPromise = null
+    }).catch(() => {})
+  }
+
+  return windowCreationPromise
+}
+
+async function appOnReady(): Promise<void> {
+  await initializeApp()
+  await openMainWindow()
+}
+
+// ---- Terminal IPC -----------------------------------------------------------
+
+ipcMain.handle('spawnTerminal', () => {
+  // Clean up any previous instance
+  if (terminalProcess && terminalProcess.isRunning()) {
+    terminalProcess.kill()
+  }
+
+  const { shell, args } = resolveShellAndArgs()
+  const { env, home } = baseEnv()
+
+  terminalProcess = new TerminalProcess(shell, args, home, env)
+
+  // Wire process events once (don’t add listeners on every keystroke)
+  terminalProcess.process.stdout.on('data', (chunk: Buffer) => {
+    mainWindow?.webContents.send('terminalOutput', chunk.toString())
+  })
+
+  terminalProcess.process.stderr.on('data', (chunk: Buffer) => {
+    mainWindow?.webContents.send('terminalOutput', chunk.toString())
+  })
+
+  terminalProcess.process.on('error', (err: Error) => {
+    mainWindow?.webContents.send('terminalOutput', `Spawn error: ${err.message}`)
+  })
+
+  terminalProcess.process.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+    mainWindow?.webContents.send(
+      'terminalOutput',
+      `\n[terminal exited: code=${code ?? 'null'} signal=${signal ?? 'null'}]`,
+    )
+  })
+
+  return { status: 'terminalStarted', pid: terminalProcess.process.pid }
+})
+
+ipcMain.on('terminalInput', (_event, input: string) => {
+  if (!terminalProcess || !terminalProcess.isRunning()) return
+  // Append newline unless you intend to send raw control sequences
+  terminalProcess.send(input.endsWith('\n') ? input : input + '\n')
+})
+
+app.on('ready', () => {
+  appOnReady().catch((err) => showInitializationError(err))
+})
 app.on('before-quit', () => {
   if (terminalProcess && terminalProcess.isRunning()) terminalProcess.kill()
 })


### PR DESCRIPTION
## Summary

  - Register terminal IPC handlers only once.
  - Prevent duplicate app initialization during startup races.
  - Guard concurrent window creation.
  - Preserve macOS close-and-reactivate behavior without restarting the edge client.

  Fixes the startup error: Attempted to register a second handler for 'spawnTerminal'.