### PR TITLE
add NVFlare 2.8 migration support

### DIFF
--- a/centralApi/package-lock.json
+++ b/centralApi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "centralapi",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "centralapi",
-      "version": "1.0.0",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.10.2",

--- a/centralApi/package.json
+++ b/centralApi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centralapi",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/centralApi/src/database/models/Run.ts
+++ b/centralApi/src/database/models/Run.ts
@@ -11,6 +11,21 @@ interface IRunError {
   message: string // Error message
 }
 
+export interface IResolvedComputationImage {
+  sourceImage: string
+  reference: string
+  digest: string
+  metadata: {
+    title: string
+    computationVersion: string
+    revision: string
+    source: string
+    computationApiVersion: string
+    boilerplateVersion: string
+    nvflareVersion: string
+  }
+}
+
 // Define an interface for the Run document
 export interface IRun extends Document {
   consortium: mongoose.Types.ObjectId // Reference to the Consortium model
@@ -20,6 +35,7 @@ export interface IRun extends Document {
   vaultMembers: mongoose.Types.ObjectId[] // Array of HostedVault references
   status: string // Could be an enum or simple string
   runErrors: IRunError[] // Array of error objects
+  resolvedComputationImage?: IResolvedComputationImage
   lastUpdated: string // String representing the numeric timestamp
   createdAt: string // String representing the numeric timestamp
 }
@@ -51,6 +67,24 @@ const runSchema: Schema = new Schema({
       message: { type: String, required: true },
     },
   ],
+  resolvedComputationImage: {
+    type: {
+      sourceImage: { type: String, required: true },
+      reference: { type: String, required: true },
+      digest: { type: String, required: true },
+      metadata: {
+        title: { type: String, required: true },
+        computationVersion: { type: String, required: true },
+        revision: { type: String, required: true },
+        source: { type: String, required: true },
+        computationApiVersion: { type: String, required: true },
+        boilerplateVersion: { type: String, required: true },
+        nvflareVersion: { type: String, required: true },
+      },
+    },
+    required: false,
+    _id: false,
+  },
 
   createdAt: { type: String, default: Date.now },
   lastUpdated: { type: String, default: Date.now },

--- a/centralApi/src/graphql/generated/graphql.ts
+++ b/centralApi/src/graphql/generated/graphql.ts
@@ -33,6 +33,27 @@ export type Computation = {
   title: Scalars['String']['output'];
 };
 
+export type ComputationImageMetadata = {
+  __typename?: 'ComputationImageMetadata';
+  boilerplateVersion: Scalars['String']['output'];
+  computationApiVersion: Scalars['String']['output'];
+  computationVersion: Scalars['String']['output'];
+  nvflareVersion: Scalars['String']['output'];
+  revision: Scalars['String']['output'];
+  source: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+};
+
+export type ComputationImageMetadataInput = {
+  boilerplateVersion: Scalars['String']['input'];
+  computationApiVersion: Scalars['String']['input'];
+  computationVersion: Scalars['String']['input'];
+  nvflareVersion: Scalars['String']['input'];
+  revision: Scalars['String']['input'];
+  source: Scalars['String']['input'];
+  title: Scalars['String']['input'];
+};
+
 export type ComputationListItem = {
   __typename?: 'ComputationListItem';
   id: Scalars['String']['output'];
@@ -317,6 +338,7 @@ export type MutationReportRunErrorArgs = {
 
 
 export type MutationReportRunReadyArgs = {
+  resolvedImage: ResolvedComputationImageInput;
   runId: Scalars['String']['input'];
 };
 
@@ -436,6 +458,21 @@ export type QueryGetRunListArgs = {
   consortiumId?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type ResolvedComputationImage = {
+  __typename?: 'ResolvedComputationImage';
+  digest: Scalars['String']['output'];
+  metadata: ComputationImageMetadata;
+  reference: Scalars['String']['output'];
+  sourceImage: Scalars['String']['output'];
+};
+
+export type ResolvedComputationImageInput = {
+  digest: Scalars['String']['input'];
+  metadata: ComputationImageMetadataInput;
+  reference: Scalars['String']['input'];
+  sourceImage: Scalars['String']['input'];
+};
+
 export type RunDetailConsortium = {
   __typename?: 'RunDetailConsortium';
   activeMembers: Array<PublicUser>;
@@ -492,6 +529,7 @@ export type RunStartCentralPayload = {
   computationParameters: Scalars['String']['output'];
   consortiumId: Scalars['String']['output'];
   imageName: Scalars['String']['output'];
+  requiredComputationApiVersion: Scalars['String']['output'];
   runId: Scalars['String']['output'];
 };
 
@@ -503,6 +541,7 @@ export type RunStartEdgePayload = {
   downloadUrl: Scalars['String']['output'];
   imageName: Scalars['String']['output'];
   participantId: Scalars['String']['output'];
+  resolvedImage: ResolvedComputationImage;
   runId: Scalars['String']['output'];
   vaultId?: Maybe<Scalars['String']['output']>;
 };

--- a/centralApi/src/graphql/generated/graphql.ts
+++ b/centralApi/src/graphql/generated/graphql.ts
@@ -333,6 +333,7 @@ export type MutationReportRunCompleteArgs = {
 
 export type MutationReportRunErrorArgs = {
   errorMessage: Scalars['String']['input'];
+  redactErrorDetails?: InputMaybe<Scalars['Boolean']['input']>;
   runId: Scalars['String']['input'];
 };
 

--- a/centralApi/src/graphql/generated/typeDefs.ts
+++ b/centralApi/src/graphql/generated/typeDefs.ts
@@ -122,6 +122,41 @@ type RunStartCentralPayload {
   activeParticipants: [ActiveParticipant!]!
   consortiumId: String!
   computationParameters: String!
+  requiredComputationApiVersion: String!
+}
+
+type ComputationImageMetadata {
+  title: String!
+  computationVersion: String!
+  revision: String!
+  source: String!
+  computationApiVersion: String!
+  boilerplateVersion: String!
+  nvflareVersion: String!
+}
+
+type ResolvedComputationImage {
+  sourceImage: String!
+  reference: String!
+  digest: String!
+  metadata: ComputationImageMetadata!
+}
+
+input ComputationImageMetadataInput {
+  title: String!
+  computationVersion: String!
+  revision: String!
+  source: String!
+  computationApiVersion: String!
+  boilerplateVersion: String!
+  nvflareVersion: String!
+}
+
+input ResolvedComputationImageInput {
+  sourceImage: String!
+  reference: String!
+  digest: String!
+  metadata: ComputationImageMetadataInput!
 }
 
 type RunStartEdgePayload {
@@ -130,6 +165,7 @@ type RunStartEdgePayload {
   vaultId: String
   computationId: String!
   imageName: String!
+  resolvedImage: ResolvedComputationImage!
   consortiumId: String!
   downloadUrl: String!
   downloadToken: String!
@@ -253,7 +289,7 @@ type Mutation {
   # used by vault federated clients
   vaultHeartbeat(heartbeat: VaultHeartbeatInput!): Boolean!
   # used by federated clients
-  reportRunReady(runId: String!): Boolean!
+  reportRunReady(runId: String!, resolvedImage: ResolvedComputationImageInput!): Boolean!
   reportRunError(runId: String!, errorMessage: String!): Boolean!
   reportRunComplete(runId: String!): Boolean!
   reportRunStatus(runId: String!, status: String!): Boolean!

--- a/centralApi/src/graphql/generated/typeDefs.ts
+++ b/centralApi/src/graphql/generated/typeDefs.ts
@@ -290,7 +290,7 @@ type Mutation {
   vaultHeartbeat(heartbeat: VaultHeartbeatInput!): Boolean!
   # used by federated clients
   reportRunReady(runId: String!, resolvedImage: ResolvedComputationImageInput!): Boolean!
-  reportRunError(runId: String!, errorMessage: String!): Boolean!
+  reportRunError(runId: String!, errorMessage: String!, redactErrorDetails: Boolean = false): Boolean!
   reportRunComplete(runId: String!): Boolean!
   reportRunStatus(runId: String!, status: String!): Boolean!
   # used by desktop App

--- a/centralApi/src/graphql/resolvers.ts
+++ b/centralApi/src/graphql/resolvers.ts
@@ -1434,7 +1434,10 @@ export default {
       }
       if (
         !/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest) ||
-        !resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+        !(
+          resolvedImage.reference === resolvedImage.digest ||
+          resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+        )
       ) {
         throw new Error('Resolved computation image digest is invalid')
       }
@@ -1512,7 +1515,15 @@ export default {
     },
     reportRunError: async (
       _: unknown,
-      { runId, errorMessage }: { runId: string; errorMessage: string },
+      {
+        runId,
+        errorMessage,
+        redactErrorDetails = false,
+      }: {
+        runId: string
+        errorMessage: string
+        redactErrorDetails?: boolean
+      },
       context: Context,
     ): Promise<boolean> => {
       logger.info('reportRunError', { runId })
@@ -1549,20 +1560,25 @@ export default {
         throw new Error('User not authorized')
       }
 
-      // Append the error to the runErrors array and update the run's status and lastUpdated fields
-      await Run.updateOne(
-        { _id: runId },
-        {
-          status: 'Error',
-          lastUpdated: Date.now().toString(), // Store as a string
-          $push: {
-            runErrors: {
-              user: context.userId, // Reference to the user who reported the error
-              message: errorMessage,
-              timestamp: Date.now().toString(), // Store as a string
-            },
+      const runUpdate: Record<string, unknown> = {
+        status: 'Error',
+        lastUpdated: Date.now().toString(),
+        $push: {
+          runErrors: {
+            user: context.userId,
+            message: redactErrorDetails
+              ? 'Site computation failed. Detailed error is available only to that participant.'
+              : errorMessage,
+            timestamp: Date.now().toString(),
           },
         },
+      }
+
+      // Site failures store only a server-generated shared notification. Their
+      // detailed marker remains private to the participant that executed them.
+      await Run.updateOne(
+        { _id: runId },
+        runUpdate,
       )
 
       const consortium = await Consortium.findById(run.consortium._id)

--- a/centralApi/src/graphql/resolvers.ts
+++ b/centralApi/src/graphql/resolvers.ts
@@ -6,7 +6,7 @@ import {
 } from '../authentication/authentication.js'
 import { CLIENT_FILE_SERVER_URL, CONSORTIUM_INVITE_URL, RESEND_API_KEY } from '../config.js'
 import Consortium from '../database/models/Consortium.js'
-import Run, { IRun } from '../database/models/Run.js'
+import Run, { IRun, IResolvedComputationImage } from '../database/models/Run.js'
 import User from '../database/models/User.js'
 import VaultServer from '../database/models/VaultServer.js'
 import HostedVault from '../database/models/HostedVault.js'
@@ -33,6 +33,7 @@ import {
 import { Resend } from 'resend'
 import { logger } from '../logger.js'
 import { randomBytes } from 'crypto'
+import { COMPUTATION_API_VERSION } from '../versions.js'
 
 interface Context {
   userId: string
@@ -1377,6 +1378,7 @@ export default {
         activeParticipants,
         consortiumId: consortium._id.toString(),
         computationParameters,
+        requiredComputationApiVersion: COMPUTATION_API_VERSION,
       })
 
       pubsub.publish('RUN_EVENT', {
@@ -1399,7 +1401,10 @@ export default {
     },
     reportRunReady: async (
       _: unknown,
-      { runId }: { runId: string },
+      {
+        runId,
+        resolvedImage,
+      }: { runId: string; resolvedImage: IResolvedComputationImage },
       context: Context,
     ): Promise<boolean> => {
       logger.info('reportRunReady', runId)
@@ -1416,11 +1421,32 @@ export default {
 
       // get the run's details from the database
       const run = await Run.findById(runId)
+      if (!run) {
+        throw new Error('Run not found')
+      }
+      if (resolvedImage.sourceImage !== run.studyConfiguration.computation.imageName) {
+        throw new Error('Resolved computation image does not match the configured image')
+      }
+      if (
+        resolvedImage.metadata.computationApiVersion !== COMPUTATION_API_VERSION
+      ) {
+        throw new Error('Resolved computation image uses an incompatible computation API')
+      }
+      if (
+        !/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest) ||
+        !resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+      ) {
+        throw new Error('Resolved computation image digest is invalid')
+      }
       await Run.updateOne(
         { _id: runId },
-        { status: 'In Progress', lastUpdated: Date.now() },
+        {
+          status: 'In Progress',
+          resolvedComputationImage: resolvedImage,
+          lastUpdated: Date.now(),
+        },
       )
-      const imageName = run.studyConfiguration.computation.imageName
+      const imageName = resolvedImage.reference
       const computationId = run.studyConfiguration.computation._id.toString()
       const consortiumId = run.consortium._id
 
@@ -1434,6 +1460,7 @@ export default {
           targetUserId: memberId.toString(),
           computationId,
           imageName,
+          resolvedImage,
           consortiumId,
         })
       })
@@ -1460,6 +1487,7 @@ export default {
           targetUserId: serverUserId.toString(),
           computationId,
           imageName,
+          resolvedImage,
           consortiumId,
         })
       })
@@ -3083,6 +3111,7 @@ export default {
           vaultId,
           computationId,
           imageName,
+          resolvedImage,
           consortiumId,
         } = payload
         // create a token
@@ -3099,6 +3128,7 @@ export default {
           vaultId: vaultId ?? null,
           computationId,
           imageName,
+          resolvedImage,
           consortiumId,
           downloadUrl: `${CLIENT_FILE_SERVER_URL}/download/${consortiumId}/${runId}/${participantId}`,
           downloadToken: accessToken,

--- a/centralApi/src/graphql/typeDefs.graphql
+++ b/centralApi/src/graphql/typeDefs.graphql
@@ -122,6 +122,41 @@ type RunStartCentralPayload {
   activeParticipants: [ActiveParticipant!]!
   consortiumId: String!
   computationParameters: String!
+  requiredComputationApiVersion: String!
+}
+
+type ComputationImageMetadata {
+  title: String!
+  computationVersion: String!
+  revision: String!
+  source: String!
+  computationApiVersion: String!
+  boilerplateVersion: String!
+  nvflareVersion: String!
+}
+
+type ResolvedComputationImage {
+  sourceImage: String!
+  reference: String!
+  digest: String!
+  metadata: ComputationImageMetadata!
+}
+
+input ComputationImageMetadataInput {
+  title: String!
+  computationVersion: String!
+  revision: String!
+  source: String!
+  computationApiVersion: String!
+  boilerplateVersion: String!
+  nvflareVersion: String!
+}
+
+input ResolvedComputationImageInput {
+  sourceImage: String!
+  reference: String!
+  digest: String!
+  metadata: ComputationImageMetadataInput!
 }
 
 type RunStartEdgePayload {
@@ -130,6 +165,7 @@ type RunStartEdgePayload {
   vaultId: String
   computationId: String!
   imageName: String!
+  resolvedImage: ResolvedComputationImage!
   consortiumId: String!
   downloadUrl: String!
   downloadToken: String!
@@ -253,7 +289,7 @@ type Mutation {
   # used by vault federated clients
   vaultHeartbeat(heartbeat: VaultHeartbeatInput!): Boolean!
   # used by federated clients
-  reportRunReady(runId: String!): Boolean!
+  reportRunReady(runId: String!, resolvedImage: ResolvedComputationImageInput!): Boolean!
   reportRunError(runId: String!, errorMessage: String!): Boolean!
   reportRunComplete(runId: String!): Boolean!
   reportRunStatus(runId: String!, status: String!): Boolean!

--- a/centralApi/src/graphql/typeDefs.graphql
+++ b/centralApi/src/graphql/typeDefs.graphql
@@ -290,7 +290,7 @@ type Mutation {
   vaultHeartbeat(heartbeat: VaultHeartbeatInput!): Boolean!
   # used by federated clients
   reportRunReady(runId: String!, resolvedImage: ResolvedComputationImageInput!): Boolean!
-  reportRunError(runId: String!, errorMessage: String!): Boolean!
+  reportRunError(runId: String!, errorMessage: String!, redactErrorDetails: Boolean = false): Boolean!
   reportRunComplete(runId: String!): Boolean!
   reportRunStatus(runId: String!, status: String!): Boolean!
   # used by desktop App

--- a/centralApi/src/index.ts
+++ b/centralApi/src/index.ts
@@ -19,6 +19,7 @@ import resolvers from './graphql/resolvers.js'
 import { httpServerContext, wsServerContext } from './serverContexts.js'
 import { validateAccessToken } from './authentication/authentication.js'
 import { APOLLO_PORT, DATABASE_URI, LOG_PATH } from './config.js'
+import { APPLICATION_API_VERSION } from './versions.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -90,6 +91,10 @@ export async function start({
 
   app.use(cors())
   app.use(bodyParser.json())
+  app.get('/version', (_req, res) => {
+    res.set('Cache-Control', 'no-store')
+    res.status(200).json({ version: APPLICATION_API_VERSION })
+  })
   app.use('/invite-assets', express.static(inviteSiteDir))
   app.use(
     '/graphql',

--- a/centralApi/src/versions.ts
+++ b/centralApi/src/versions.ts
@@ -1,0 +1,2 @@
+export const APPLICATION_API_VERSION = '0.8.0'
+export const COMPUTATION_API_VERSION = '0.1.0'

--- a/centralFederatedClient/dev-start.js
+++ b/centralFederatedClient/dev-start.js
@@ -70,11 +70,18 @@ try {
   }
 }
 
+// This launcher is development-only. Prefer an already-built local computation
+// image unless the developer explicitly asks to exercise registry resolution.
+if (!process.env.COMPUTATION_IMAGE_MODE) {
+  process.env.COMPUTATION_IMAGE_MODE = 'local'
+}
+
 // Now run the actual service
 const child = spawn('npm', ['start'], {
   stdio: 'inherit',
   shell: true,
   cwd: __dirname,
+  env: process.env,
 })
 
 child.on('exit', (code) => {

--- a/centralFederatedClient/package.json
+++ b/centralFederatedClient/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "tsc",
+    "test": "npm run compile && node --test tests/sharedError.test.mjs",
     "start": "npm run compile && node ./dist/index.js"
   },
   "type": "module",

--- a/centralFederatedClient/src/config.ts
+++ b/centralFederatedClient/src/config.ts
@@ -18,3 +18,13 @@ export const FQDN = requireEnv('FQDN')
 export const LOG_PATH = requireEnvOptional('LOG_PATH')
 export const HOSTING_PORT_START = Number(requireEnv('HOSTING_PORT_START'))
 export const HOSTING_PORT_END = Number(requireEnv('HOSTING_PORT_END'))
+
+const computationImageMode = process.env.COMPUTATION_IMAGE_MODE ?? 'registry'
+if (!['local', 'registry'].includes(computationImageMode)) {
+  throw new Error(
+    'COMPUTATION_IMAGE_MODE must be either "local" or "registry"',
+  )
+}
+export const COMPUTATION_IMAGE_MODE = computationImageMode as
+  | 'local'
+  | 'registry'

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/portManagement.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/portManagement.ts
@@ -58,6 +58,22 @@ export async function reservePort({
   })
 }
 
+export async function releasePortReservation(server: net.Server): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
 function createServer(): net.Server {
   return net.createServer((sock) => {
     sock.end('Hello world\n')

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/provisionRun/provisionRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/provisionRun/provisionRun.ts
@@ -17,7 +17,6 @@ interface provisionRunArgs {
   pathRun: string
   computationParameters: string
   fedLearnPort: number
-  adminPort: number
   FQDN: string
 }
 
@@ -27,7 +26,6 @@ export async function provisionRun({
   computationParameters,
   pathRun,
   fedLearnPort,
-  adminPort,
   FQDN,
 }: provisionRunArgs) {
   const pathHosting = path.join(pathRun, 'hosting')
@@ -35,15 +33,14 @@ export async function provisionRun({
   await ensureDirectoryExists(pathRun)
   await ensureDirectoryExists(pathHosting)
 
-  const participantIds = activeParticipants.map((participant) => participant.participantId)
-
   // make the input
   const provisionInput = {
-    active_participants: activeParticipants,
-    user_ids: participantIds,
+    users: activeParticipants.map(({ participantId, displayName }) => ({
+      id: participantId,
+      name: displayName,
+    })),
     computation_parameters: computationParameters,
     fed_learn_port: fedLearnPort,
-    admin_port: adminPort,
     host_identifier: FQDN,
   }
 
@@ -71,6 +68,7 @@ export async function provisionRun({
       ],
       portBindings: [],
       commandsToRun: ['python', '/workspace/system/entry_provision.py'],
+      failureLogPath: path.join(pathRun, 'provision-failed-container.log'),
       onContainerExitSuccess: () => resolve(undefined),
       onContainerExitError: (_, error) => reject(new Error(error)),
     }).catch(reject)

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/runStartHandler.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/runStartHandler.ts
@@ -16,6 +16,7 @@ export const RUN_START_SUBSCRIPTION = `
         vaultId
       }
       computationParameters
+      requiredComputationApiVersion
       imageName
     }
   }
@@ -32,23 +33,25 @@ export const runStartHandler = {
       runId,
       activeParticipants,
       computationParameters,
+      requiredComputationApiVersion,
       imageName,
     } = data.runStartCentral
 
     try {
-      await startRun({
+      const resolvedImage = await startRun({
         imageName,
         activeParticipants,
         consortiumId,
         runId,
         computationParameters,
+        requiredComputationApiVersion,
       })
 
       // wait a 1 second to report run ready
       await new Promise((resolve) => setTimeout(resolve, 1000))
 
       // report to the central api that the run is ready
-      return await reportRunReady({ runId })
+      return await reportRunReady({ runId, resolvedImage })
     } catch (error) {
       logger.error('Error in Run Start Central:', { error })
 

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
@@ -67,7 +67,7 @@ export default async function startRun({
     await fs.mkdir(pathCentralResults, { recursive: true, mode: 0o700 })
     await fs.chmod(pathCentralResults, 0o700)
 
-    // Reserve the multiplexed federation and administration port
+    // NVFlare 2.8 uses one externally routed server port for this computation API.
     const {
       port: reservedFedLearnPort,
       server: fedLearnServer,
@@ -112,7 +112,7 @@ export default async function startRun({
           containerDirectory: '/workspace/output/',
         },
       ],
-      portBindings: [{ hostPort: fedLearnPort, containerPort: fedLearnPort }],
+    portBindings: [{ hostPort: fedLearnPort, containerPort: fedLearnPort }],
       commandsToRun: ['python', '/workspace/system/entry_central.py'],
       failureLogPath: path.join(pathRun, 'central-failed-container.log'),
       onContainerExitSuccess: () => reportRunComplete({ runId }),

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
@@ -1,9 +1,12 @@
 import path from 'path'
 import { provisionRun } from './provisionRun/provisionRun.js'
-import { reservePort } from './portManagement.js'
 import {
-  ensureDockerImageReady,
+  releasePortReservation,
+  reservePort,
+} from './portManagement.js'
+import {
   launchNode,
+  resolveDockerComputationImage,
 } from '../../nodeManager/launchNode.js'
 import uploadToFileServer from './uploadToFileServer.js'
 import reportRunError from '../../report/reportRunError.js'
@@ -25,6 +28,7 @@ interface StartRunArgs {
   consortiumId: string
   runId: string
   computationParameters: string
+  requiredComputationApiVersion: string
 }
 
 export default async function startRun({
@@ -33,6 +37,7 @@ export default async function startRun({
   consortiumId,
   runId,
   computationParameters,
+  requiredComputationApiVersion,
 }: StartRunArgs) {
   logger.info(`Starting run ${runId} for consortium ${consortiumId}`)
 
@@ -42,32 +47,30 @@ export default async function startRun({
     start: HOSTING_PORT_START,
     end: HOSTING_PORT_END,
   }
+  let releaseFedLearnPort: (() => Promise<void>) | undefined
 
   try {
-    // Refresh floating tags once, then pin both run phases to the same local image.
-    const resolvedImageName = await ensureDockerImageReady(imageName)
+    const resolvedImage = await resolveDockerComputationImage(
+      imageName,
+      requiredComputationApiVersion,
+    )
 
-    // Reserve ports for federated learning and admin servers
+    // Reserve the multiplexed federation and administration port
     const {
       port: reservedFedLearnPort,
       server: fedLearnServer,
     } = await reservePort(hostingPortRange)
-    const {
-      port: reservedAdminPort,
-      server: adminServer,
-    } = await reservePort(hostingPortRange)
     const fedLearnPort = reservedFedLearnPort
-    const adminPort = reservedAdminPort
+    releaseFedLearnPort = () => releasePortReservation(fedLearnServer)
 
     // Provision the run
     logger.info(`Provisioning run ${runId}`)
     await provisionRun({
-      imageName: resolvedImageName,
+      imageName: resolvedImage.reference,
       activeParticipants,
       pathRun,
       computationParameters,
       fedLearnPort,
-      adminPort,
       FQDN,
     })
 
@@ -79,31 +82,38 @@ export default async function startRun({
       pathBaseDirectory: BASE_DIR,
     })
 
-    // Close the reserved servers before launching the Docker container
-    fedLearnServer.close()
-    adminServer.close()
+    // Release and fully close the reservation before Docker binds the port.
+    await releaseFedLearnPort()
+    releaseFedLearnPort = undefined
 
     // Launch the Docker node
     await launchNode({
       containerService: 'docker',
-      imageName: resolvedImageName,
+      imageName: resolvedImage.reference,
       directoriesToMount: [
         {
           hostDirectory: pathCentralNodeRunKit,
           containerDirectory: '/workspace/runKit/',
         },
       ],
-      portBindings: [
-        { hostPort: fedLearnPort, containerPort: fedLearnPort },
-        { hostPort: adminPort, containerPort: adminPort },
-      ],
+      portBindings: [{ hostPort: fedLearnPort, containerPort: fedLearnPort }],
       commandsToRun: ['python', '/workspace/system/entry_central.py'],
+      failureLogPath: path.join(pathRun, 'central-failed-container.log'),
       onContainerExitSuccess: () => reportRunComplete({ runId }),
       onContainerExitError: (_, error) =>
         reportRunError({ runId, errorMessage: error }),
     })
-  } catch (error) {
-    logger.error('Start Run Failed', { error })
-    await reportRunError({ runId, errorMessage: (error as Error).message })
+    return resolvedImage
+  } finally {
+    if (releaseFedLearnPort) {
+      try {
+        await releaseFedLearnPort()
+      } catch (releaseError) {
+        logger.error('Failed to release reserved federation port', {
+          error: releaseError,
+          runId,
+        })
+      }
+    }
   }
 }

--- a/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
+++ b/centralFederatedClient/src/runCoordinator/eventHandlers/runStart/startRun.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { promises as fs } from 'fs'
 import { provisionRun } from './provisionRun/provisionRun.js'
 import {
   releasePortReservation,
@@ -12,7 +13,14 @@ import uploadToFileServer from './uploadToFileServer.js'
 import reportRunError from '../../report/reportRunError.js'
 import reportRunComplete from '../../report/reportRunComplete.js'
 import { logger } from '../../../logger.js'
-import { BASE_DIR, FQDN, HOSTING_PORT_END, HOSTING_PORT_START } from '../../../config.js'
+import {
+  BASE_DIR,
+  COMPUTATION_IMAGE_MODE,
+  FQDN,
+  HOSTING_PORT_END,
+  HOSTING_PORT_START,
+} from '../../../config.js'
+import { readTerminalError } from '../../terminalError.js'
 
 interface ActiveParticipant {
   participantId: string
@@ -43,6 +51,7 @@ export default async function startRun({
 
   const pathRun = path.join(BASE_DIR, 'runs', consortiumId, runId)
   const pathCentralNodeRunKit = path.join(pathRun, 'runKits', 'centralNode')
+  const pathCentralResults = path.join(pathRun, 'central-results')
   const hostingPortRange = {
     start: HOSTING_PORT_START,
     end: HOSTING_PORT_END,
@@ -53,7 +62,10 @@ export default async function startRun({
     const resolvedImage = await resolveDockerComputationImage(
       imageName,
       requiredComputationApiVersion,
+      COMPUTATION_IMAGE_MODE,
     )
+    await fs.mkdir(pathCentralResults, { recursive: true, mode: 0o700 })
+    await fs.chmod(pathCentralResults, 0o700)
 
     // Reserve the multiplexed federation and administration port
     const {
@@ -95,13 +107,37 @@ export default async function startRun({
           hostDirectory: pathCentralNodeRunKit,
           containerDirectory: '/workspace/runKit/',
         },
+        {
+          hostDirectory: pathCentralResults,
+          containerDirectory: '/workspace/output/',
+        },
       ],
       portBindings: [{ hostPort: fedLearnPort, containerPort: fedLearnPort }],
       commandsToRun: ['python', '/workspace/system/entry_central.py'],
       failureLogPath: path.join(pathRun, 'central-failed-container.log'),
       onContainerExitSuccess: () => reportRunComplete({ runId }),
-      onContainerExitError: (_, error) =>
-        reportRunError({ runId, errorMessage: error }),
+      onContainerExitError: async (_, error) => {
+        let terminalError: Awaited<ReturnType<typeof readTerminalError>>
+        try {
+          terminalError = await readTerminalError(pathCentralResults)
+        } catch (markerError) {
+          logger.error('Failed to read the central terminal error marker', {
+            error: markerError,
+            runId,
+          })
+        }
+        if (terminalError?.origin === 'site') {
+          logger.info('Central container relayed a site failure; not recording it twice', {
+            runId,
+          })
+          return
+        }
+        await reportRunError({
+          runId,
+          errorMessage:
+            terminalError?.displayMessage ?? `Central runtime failure: ${error}`,
+        })
+      },
     })
     return resolvedImage
   } finally {

--- a/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -2,6 +2,7 @@ import Docker from 'dockerode'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import { logger } from '../../logger.js'
+import { extractSharedError } from './sharedError.js'
 const docker = new Docker()
 
 const MAX_FAILURE_LOG_BYTES = 1024 * 1024
@@ -182,7 +183,10 @@ const attachDockerEventHandlers = async ({
       })
       await captureFailedContainerLogs(container, failureLogPath)
       if (onContainerExitError) {
-        await onContainerExitError(containerId, (waitError as Error).message)
+        await onContainerExitError(
+          containerId,
+          'Central computation container could not be monitored',
+        )
       }
       return
     }
@@ -191,9 +195,13 @@ const attachDockerEventHandlers = async ({
       logger.error(
         `Container ${containerId} exited with error code ${statusCode}`,
       )
-      await captureFailedContainerLogs(container, failureLogPath)
+      const localLogs = await captureFailedContainerLogs(container, failureLogPath)
+      const sharedError = extractSharedError(
+        localLogs,
+        `Computation container exited with code ${statusCode}`,
+      )
       if (onContainerExitError) {
-        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+        await onContainerExitError(containerId, sharedError)
       }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
@@ -220,11 +228,7 @@ const attachDockerEventHandlers = async ({
 const captureFailedContainerLogs = async (
   container: ReturnType<typeof docker.getContainer>,
   failureLogPath?: string,
-): Promise<void> => {
-  if (!failureLogPath) {
-    return
-  }
-
+): Promise<string> => {
   try {
     const rawLogs = await container.logs({
       stdout: true,
@@ -233,6 +237,9 @@ const captureFailedContainerLogs = async (
       tail: 10000,
     })
     const decodedLogs = decodeDockerLogs(rawLogs)
+    if (!failureLogPath) {
+      return decodedLogs
+    }
     const logBuffer = Buffer.from(decodedLogs, 'utf8')
     const wasTruncated = logBuffer.length > MAX_FAILURE_LOG_BYTES
     const retainedLogs = wasTruncated
@@ -253,10 +260,12 @@ const captureFailedContainerLogs = async (
     )
     await fs.chmod(failureLogPath, 0o600)
     logger.info(`Saved failed-container logs to ${failureLogPath}`)
+    return decodedLogs
   } catch (logError) {
     logger.warn(`Could not save failed-container logs for ${container.id}`, {
       error: logError,
     })
+    return ''
   }
 }
 
@@ -303,6 +312,19 @@ const getLocalDockerImageId = async (
     }
 
     throw error
+  }
+}
+
+const validateImageCompatibility = async (imageName: string): Promise<void> => {
+  const image = await docker.getImage(imageName).inspect()
+  const labels = image.Config?.Labels ?? {}
+  for (const [label, expected] of Object.entries(REQUIRED_IMAGE_LABELS)) {
+    const actual = labels[label]
+    if (actual !== expected) {
+      throw new Error(
+        `Image "${imageName}" is incompatible: label "${label}" must be "${expected}"`,
+      )
+    }
   }
 }
 
@@ -426,6 +448,11 @@ const validateComputationImageMetadata = (
   if (metadata.nvflareVersion !== '2.8.0') {
     throw new Error(
       `NVFlare ${metadata.nvflareVersion} is incompatible with required version 2.8.0`,
+    )
+  }
+  if (metadata.boilerplateVersion !== '0.1.0') {
+    throw new Error(
+      `Boilerplate ${metadata.boilerplateVersion} is incompatible with required version 0.1.0`,
     )
   }
 }

--- a/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -1,6 +1,39 @@
 import Docker from 'dockerode'
+import { promises as fs } from 'fs'
+import * as path from 'path'
 import { logger } from '../../logger.js'
 const docker = new Docker()
+
+const MAX_FAILURE_LOG_BYTES = 1024 * 1024
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
+
+export interface ComputationImageMetadata {
+  title: string
+  computationVersion: string
+  revision: string
+  source: string
+  computationApiVersion: string
+  boilerplateVersion: string
+  nvflareVersion: string
+}
+
+export interface ResolvedComputationImage {
+  sourceImage: string
+  reference: string
+  digest: string
+  metadata: ComputationImageMetadata
+}
+
+const REQUIRED_IMAGE_LABELS = {
+  title: 'org.opencontainers.image.title',
+  computationVersion: 'org.opencontainers.image.version',
+  revision: 'org.opencontainers.image.revision',
+  source: 'org.opencontainers.image.source',
+  computationApiVersion: 'org.neuroflame.computation-api.version',
+  boilerplateVersion: 'org.neuroflame.boilerplate.version',
+  nvflareVersion: 'org.neuroflame.nvflare.version',
+} as const
 
 interface LaunchNodeArgs {
   containerService: string
@@ -8,14 +41,16 @@ interface LaunchNodeArgs {
   directoriesToMount: Array<{
     hostDirectory: string
     containerDirectory: string
+    readOnly?: boolean
   }>
   portBindings: Array<{
     hostPort: number
     containerPort: number
   }>
   commandsToRun: string[]
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }
 
 interface ExposedPorts {
@@ -32,6 +67,7 @@ export async function launchNode({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: LaunchNodeArgs) {
@@ -45,6 +81,7 @@ export async function launchNode({
     directoriesToMount,
     portBindings,
     commandsToRun,
+    failureLogPath,
     onContainerExitSuccess,
     onContainerExitError,
   })
@@ -55,6 +92,7 @@ const launchDockerNode = async ({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: Omit<LaunchNodeArgs, 'containerService'>) => {
@@ -63,7 +101,8 @@ const launchDockerNode = async ({
   )
 
   const binds = directoriesToMount.map(
-    (mount) => `${mount.hostDirectory}:${mount.containerDirectory}`,
+    (mount) =>
+      `${mount.hostDirectory}:${mount.containerDirectory}:${mount.readOnly ? 'ro' : 'rw'}`,
   )
   const exposedPorts: ExposedPorts = {}
   const portBindingsFormatted: PortBindings = {}
@@ -76,6 +115,9 @@ const launchDockerNode = async ({
 
   try {
     const resolvedImageName = await ensureDockerImageReady(imageName)
+    if (failureLogPath) {
+      await fs.rm(failureLogPath, { force: true })
+    }
 
     // Create the container
     const container = await docker.createContainer({
@@ -84,6 +126,8 @@ const launchDockerNode = async ({
       ExposedPorts: exposedPorts,
       HostConfig: {
         Binds: binds,
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges:true'],
         PortBindings: portBindingsFormatted,
         NetworkMode: process.env.CI === 'true' ? 'ci-network' : 'bridge',
         ExtraHosts: process.env.CI === 'true'
@@ -99,6 +143,7 @@ const launchDockerNode = async ({
     // Add event handlers for the container
     attachDockerEventHandlers({
       containerId: container.id,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -115,34 +160,125 @@ const launchDockerNode = async ({
 
 const attachDockerEventHandlers = async ({
   containerId,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: {
   containerId: string
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }) => {
   const container = docker.getContainer(containerId)
 
   try {
-    const { StatusCode } = await container.wait()
-    if (StatusCode !== 0) {
+    let statusCode: number
+    try {
+      const waitResult = await container.wait()
+      statusCode = waitResult.StatusCode
+    } catch (waitError) {
+      logger.error(`Error waiting for container ${containerId}`, {
+        error: waitError,
+      })
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, (waitError as Error).message)
+      }
+      return
+    }
+
+    if (statusCode !== 0) {
       logger.error(
-        `Container ${containerId} exited with error code ${StatusCode}`,
+        `Container ${containerId} exited with error code ${statusCode}`,
       )
-      const logs = await container.logs({ stdout: true, stderr: true })
-      logger.error(`Logs from container ${containerId}: ${logs}`)
-      onContainerExitError &&
-        onContainerExitError(containerId, `Exit Code: ${StatusCode}`)
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+      }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
-      onContainerExitSuccess && onContainerExitSuccess(containerId)
+      if (onContainerExitSuccess) {
+        await onContainerExitSuccess(containerId)
+      }
     }
-  } catch (error) {
-    logger.error(`Error waiting for container ${containerId}`, { error })
-    onContainerExitError &&
-      onContainerExitError(containerId, (error as Error).message)
+  } catch (handlerError) {
+    logger.error(`Failed to handle exit for container ${containerId}`, {
+      error: handlerError,
+    })
+  } finally {
+    try {
+      await container.remove()
+      logger.info(`Removed completed container ${containerId}`)
+    } catch (removeError) {
+      logger.warn(`Failed to remove completed container ${containerId}`, {
+        error: removeError,
+      })
+    }
   }
+}
+
+const captureFailedContainerLogs = async (
+  container: ReturnType<typeof docker.getContainer>,
+  failureLogPath?: string,
+): Promise<void> => {
+  if (!failureLogPath) {
+    return
+  }
+
+  try {
+    const rawLogs = await container.logs({
+      stdout: true,
+      stderr: true,
+      timestamps: true,
+      tail: 10000,
+    })
+    const decodedLogs = decodeDockerLogs(rawLogs)
+    const logBuffer = Buffer.from(decodedLogs, 'utf8')
+    const wasTruncated = logBuffer.length > MAX_FAILURE_LOG_BYTES
+    const retainedLogs = wasTruncated
+      ? logBuffer.subarray(logBuffer.length - MAX_FAILURE_LOG_BYTES)
+      : logBuffer
+    const prefix = wasTruncated
+      ? `[truncated to last ${MAX_FAILURE_LOG_BYTES} bytes]\n`
+      : ''
+
+    await fs.mkdir(path.dirname(failureLogPath), {
+      recursive: true,
+      mode: 0o700,
+    })
+    await fs.writeFile(
+      failureLogPath,
+      Buffer.concat([Buffer.from(prefix, 'utf8'), retainedLogs]),
+      { mode: 0o600 },
+    )
+    await fs.chmod(failureLogPath, 0o600)
+    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+  } catch (logError) {
+    logger.warn(`Could not save failed-container logs for ${container.id}`, {
+      error: logError,
+    })
+  }
+}
+
+const decodeDockerLogs = (rawLogs: Buffer): string => {
+  const chunks: Buffer[] = []
+  let offset = 0
+
+  while (offset + 8 <= rawLogs.length) {
+    const streamType = rawLogs[offset]
+    const payloadLength = rawLogs.readUInt32BE(offset + 4)
+    const payloadStart = offset + 8
+    const payloadEnd = payloadStart + payloadLength
+    if (![0, 1, 2].includes(streamType) || payloadEnd > rawLogs.length) {
+      return rawLogs.toString('utf8')
+    }
+    chunks.push(rawLogs.subarray(payloadStart, payloadEnd))
+    offset = payloadEnd
+  }
+
+  return offset === rawLogs.length && chunks.length > 0
+    ? Buffer.concat(chunks).toString('utf8')
+    : rawLogs.toString('utf8')
 }
 
 const isDockerRunning = async () => {
@@ -182,6 +318,94 @@ const shouldPullBeforeRun = (imageName: string): boolean => {
   return !imageWithoutRegistryPort.includes(':') || imageName.endsWith(':latest')
 }
 
+const readComputationImageMetadata = (
+  labels: Record<string, string> | undefined,
+): ComputationImageMetadata => {
+  const metadata = Object.fromEntries(
+    Object.entries(REQUIRED_IMAGE_LABELS).map(([field, label]) => {
+      const value = labels?.[label]?.trim()
+      if (!value) {
+        throw new Error(`Computation image is missing required label "${label}"`)
+      }
+      return [field, value]
+    }),
+  ) as unknown as ComputationImageMetadata
+
+  for (const field of [
+    'computationVersion',
+    'computationApiVersion',
+    'boilerplateVersion',
+    'nvflareVersion',
+  ] as const) {
+    if (!SEMVER_PATTERN.test(metadata[field])) {
+      throw new Error(`Computation image label ${field} is not semantic versioning`)
+    }
+  }
+  if (!/^[0-9a-f]{7,64}$/.test(metadata.revision)) {
+    throw new Error('Computation image revision label is not a Git revision')
+  }
+  return metadata
+}
+
+export const resolveDockerComputationImage = async (
+  imageName: string,
+  requiredComputationApiVersion: string,
+): Promise<ResolvedComputationImage> => {
+  await isDockerRunning()
+  if (imageName.includes('@sha256:')) {
+    try {
+      await pullDockerImage(imageName)
+    } catch (error) {
+      if (!await getLocalDockerImageId(imageName)) {
+        throw error
+      }
+      logger.warn(`Registry unavailable; using cached immutable image ${imageName}`, {
+        error,
+      })
+    }
+  } else {
+    await pullDockerImage(imageName)
+  }
+
+  const inspection = await docker.getImage(imageName).inspect()
+  const metadata = readComputationImageMetadata(inspection.Config?.Labels)
+  if (metadata.computationApiVersion !== requiredComputationApiVersion) {
+    throw new Error(
+      `Computation API ${metadata.computationApiVersion} is incompatible with required version ${requiredComputationApiVersion}`,
+    )
+  }
+  if (metadata.nvflareVersion !== '2.8.0') {
+    throw new Error(
+      `NVFlare ${metadata.nvflareVersion} is incompatible with required version 2.8.0`,
+    )
+  }
+
+  const suppliedDigest = imageName.match(/@(sha256:[0-9a-f]{64})$/)?.[1]
+  const sourceRepository = imageName
+    .replace(/@sha256:[0-9a-f]{64}$/, '')
+    .replace(/:[^/:]+$/, '')
+  const repositoryDigest = suppliedDigest
+    ? imageName
+    : inspection.RepoDigests?.find(
+      (value) =>
+        value.startsWith(`${sourceRepository}@`) && value.includes('@sha256:'),
+    )
+  if (!repositoryDigest) {
+    throw new Error(`Unable to resolve a registry digest for image "${imageName}"`)
+  }
+  const digest = repositoryDigest.slice(repositoryDigest.lastIndexOf('@') + 1)
+  if (!DIGEST_PATTERN.test(digest)) {
+    throw new Error(`Docker returned an invalid image digest: ${digest}`)
+  }
+
+  return {
+    sourceImage: imageName,
+    reference: repositoryDigest,
+    digest,
+    metadata,
+  }
+}
+
 const pullDockerImage = async (imageName: string): Promise<void> => {
   logger.info(`Pulling Docker image before run: ${imageName}`)
 
@@ -217,20 +441,7 @@ export const ensureDockerImageReady = async (
   await isDockerRunning()
 
   if (shouldPullBeforeRun(imageName)) {
-    try {
-      await pullDockerImage(imageName)
-    } catch (error) {
-      const localImageId = await getLocalDockerImageId(imageName)
-      if (!localImageId) {
-        throw error
-      }
-
-      logger.warn(
-        `Failed to refresh Docker image ${imageName}; using cached image ${localImageId}`,
-        { error },
-      )
-      return localImageId
-    }
+    await pullDockerImage(imageName)
   }
 
   const localImageId = await getLocalDockerImageId(imageName)
@@ -240,5 +451,5 @@ export const ensureDockerImageReady = async (
     )
   }
 
-  return localImageId
+  return imageName
 }

--- a/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -350,8 +350,25 @@ const readComputationImageMetadata = (
 export const resolveDockerComputationImage = async (
   imageName: string,
   requiredComputationApiVersion: string,
+  mode: 'local' | 'registry' = 'registry',
 ): Promise<ResolvedComputationImage> => {
   await isDockerRunning()
+  if (mode === 'local') {
+    const inspection = await docker.getImage(imageName).inspect()
+    const metadata = readComputationImageMetadata(inspection.Config?.Labels)
+    validateComputationImageMetadata(metadata, requiredComputationApiVersion)
+    if (!DIGEST_PATTERN.test(inspection.Id)) {
+      throw new Error(`Docker returned an invalid local image ID: ${inspection.Id}`)
+    }
+    logger.info(`Using local computation image ${imageName} as ${inspection.Id}`)
+    return {
+      sourceImage: imageName,
+      reference: inspection.Id,
+      digest: inspection.Id,
+      metadata,
+    }
+  }
+
   if (imageName.includes('@sha256:')) {
     try {
       await pullDockerImage(imageName)
@@ -369,16 +386,7 @@ export const resolveDockerComputationImage = async (
 
   const inspection = await docker.getImage(imageName).inspect()
   const metadata = readComputationImageMetadata(inspection.Config?.Labels)
-  if (metadata.computationApiVersion !== requiredComputationApiVersion) {
-    throw new Error(
-      `Computation API ${metadata.computationApiVersion} is incompatible with required version ${requiredComputationApiVersion}`,
-    )
-  }
-  if (metadata.nvflareVersion !== '2.8.0') {
-    throw new Error(
-      `NVFlare ${metadata.nvflareVersion} is incompatible with required version 2.8.0`,
-    )
-  }
+  validateComputationImageMetadata(metadata, requiredComputationApiVersion)
 
   const suppliedDigest = imageName.match(/@(sha256:[0-9a-f]{64})$/)?.[1]
   const sourceRepository = imageName
@@ -403,6 +411,22 @@ export const resolveDockerComputationImage = async (
     reference: repositoryDigest,
     digest,
     metadata,
+  }
+}
+
+const validateComputationImageMetadata = (
+  metadata: ComputationImageMetadata,
+  requiredComputationApiVersion: string,
+): void => {
+  if (metadata.computationApiVersion !== requiredComputationApiVersion) {
+    throw new Error(
+      `Computation API ${metadata.computationApiVersion} is incompatible with required version ${requiredComputationApiVersion}`,
+    )
+  }
+  if (metadata.nvflareVersion !== '2.8.0') {
+    throw new Error(
+      `NVFlare ${metadata.nvflareVersion} is incompatible with required version 2.8.0`,
+    )
   }
 }
 

--- a/centralFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
+++ b/centralFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
@@ -1,0 +1,66 @@
+const SHARED_ERROR_PREFIX = 'NEUROFLAME_SHARED_ERROR:'
+const DOCKER_TIMESTAMP_PREFIX = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{1,9})?Z /
+
+const ERROR_MESSAGES = {
+  central_computation_failed: {
+    startup: 'Central computation failed during startup',
+    execution: 'Central computation failed during execution',
+    aggregation: 'Central computation failed during aggregation',
+    transfer: 'Central computation failed during artifact transfer',
+  },
+  participant_computation_failed: {
+    startup: 'Participant computation failed during startup',
+    execution: 'Participant computation failed during execution',
+    aggregation: 'Participant computation failed during aggregation',
+    transfer: 'Participant computation failed during artifact transfer',
+  },
+} as const
+
+type ErrorCode = keyof typeof ERROR_MESSAGES
+type ErrorStage = keyof (typeof ERROR_MESSAGES)[ErrorCode]
+
+interface SharedErrorEnvelope {
+  schema_version: 1
+  origin: 'central' | 'site'
+  stage: ErrorStage
+  code: ErrorCode
+}
+
+const isSharedErrorEnvelope = (value: unknown): value is SharedErrorEnvelope => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  if (candidate.schema_version !== 1) return false
+  if (candidate.origin !== 'central' && candidate.origin !== 'site') return false
+  if (
+    candidate.code !== 'central_computation_failed'
+    && candidate.code !== 'participant_computation_failed'
+  ) return false
+  if (
+    candidate.stage !== 'startup'
+    && candidate.stage !== 'execution'
+    && candidate.stage !== 'aggregation'
+    && candidate.stage !== 'transfer'
+  ) return false
+  return (
+    (candidate.origin === 'central' && candidate.code === 'central_computation_failed')
+    || (candidate.origin === 'site' && candidate.code === 'participant_computation_failed')
+  )
+}
+
+export const extractSharedError = (logs: string, fallback: string): string => {
+  const encodedLines = logs
+    .split(/\r?\n/)
+    .map((line) => line.replace(DOCKER_TIMESTAMP_PREFIX, ''))
+    .filter((line) => line.startsWith(SHARED_ERROR_PREFIX))
+  for (const line of encodedLines) {
+    try {
+      const envelope: unknown = JSON.parse(line.slice(SHARED_ERROR_PREFIX.length))
+      if (isSharedErrorEnvelope(envelope)) {
+        return ERROR_MESSAGES[envelope.code][envelope.stage]
+      }
+    } catch {
+      // Ignore malformed computation output and use an orchestrator-owned fallback.
+    }
+  }
+  return fallback
+}

--- a/centralFederatedClient/src/runCoordinator/report/reportRunReady.ts
+++ b/centralFederatedClient/src/runCoordinator/report/reportRunReady.ts
@@ -1,6 +1,7 @@
 import { ACCESS_TOKEN, HTTP_URL } from '../../config.js'
 import { logger } from '../../logger.js'
 import fetch from 'node-fetch' // Import node-fetch
+import type { ResolvedComputationImage } from '../nodeManager/launchNode.js'
 
 // TypeScript interfaces for the GraphQL response
 interface GraphQLResponse<T> {
@@ -17,12 +18,18 @@ interface ReportRunReadyResponse {
 
 // GraphQL mutation
 const REPORT_RUN_READY_MUTATION = `
-  mutation reportRunReady($runId: String!) {
-    reportRunReady(runId: $runId)
+  mutation reportRunReady($runId: String!, $resolvedImage: ResolvedComputationImageInput!) {
+    reportRunReady(runId: $runId, resolvedImage: $resolvedImage)
   }
 `
 
-export default async function reportReady({ runId }: { runId: string }) {
+export default async function reportReady({
+  runId,
+  resolvedImage,
+}: {
+  runId: string
+  resolvedImage: ResolvedComputationImage
+}) {
   try {
     const response = await fetch(HTTP_URL, {
       method: 'POST',
@@ -32,7 +39,7 @@ export default async function reportReady({ runId }: { runId: string }) {
       },
       body: JSON.stringify({
         query: REPORT_RUN_READY_MUTATION,
-        variables: { runId },
+        variables: { runId, resolvedImage },
       }),
     })
 

--- a/centralFederatedClient/src/runCoordinator/terminalError.ts
+++ b/centralFederatedClient/src/runCoordinator/terminalError.ts
@@ -1,0 +1,77 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const TERMINAL_ERROR_FILE = '.neuroflame_error.json'
+const ERROR_SCHEMA_VERSION = 1
+const MAX_ERROR_FIELD_LENGTH = 2000
+
+export interface TerminalError {
+  origin: 'site' | 'central' | 'unknown'
+  stage?: string
+  scope?: string
+  errorType?: string
+  message: string
+  displayMessage: string
+}
+
+interface TerminalErrorMarker {
+  schema_version?: unknown
+  origin?: unknown
+  stage?: unknown
+  scope?: unknown
+  error_type?: unknown
+  message?: unknown
+}
+
+const cleanField = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const cleaned = value.trim().slice(0, MAX_ERROR_FIELD_LENGTH)
+  return cleaned || undefined
+}
+
+export const readTerminalError = async (
+  outputDirectory: string,
+): Promise<TerminalError | undefined> => {
+  try {
+    const markerPath = path.join(outputDirectory, TERMINAL_ERROR_FILE)
+    const marker = JSON.parse(
+      await fs.readFile(markerPath, 'utf8'),
+    ) as TerminalErrorMarker
+    const scope = cleanField(marker.scope)
+    const stage = cleanField(marker.stage)
+    const errorType = cleanField(marker.error_type)
+    const message = cleanField(marker.message)
+
+    if (!message) {
+      return undefined
+    }
+
+    const origin = marker.schema_version === ERROR_SCHEMA_VERSION &&
+      (marker.origin === 'site' || marker.origin === 'central')
+      ? marker.origin
+      : 'unknown'
+    const context = [scope && `[${scope}]`, errorType && `${errorType}:`]
+      .filter(Boolean)
+      .join(' ')
+    const displayMessage = origin === 'central'
+      ? `Central computation failure: ${context ? `${context} ` : ''}${message}`
+      : 'Central computation failed. Detailed error is available in the central run results.'
+
+    return {
+      origin,
+      stage,
+      scope,
+      errorType,
+      message,
+      displayMessage,
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined
+    }
+    throw error
+  }
+}

--- a/centralFederatedClient/tests/sharedError.test.mjs
+++ b/centralFederatedClient/tests/sharedError.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { extractSharedError } from '../dist/runCoordinator/nodeManager/sharedError.js'
+
+test('accepts only allowlisted shared-error envelopes', () => {
+  const valid = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"transfer","code":"participant_computation_failed"}'
+  assert.equal(
+    extractSharedError(valid, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+  assert.equal(
+    extractSharedError(`ordinary log line\n2026-08-06T23:59:00.123456789Z ${valid}`, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+
+  const arbitrary = 'NEUROFLAME_SHARED_ERROR:"patient subject-123"'
+  assert.equal(extractSharedError(arbitrary, 'fallback'), 'fallback')
+
+  const injectedStage = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"subject-123","code":"participant_computation_failed"}'
+  assert.equal(extractSharedError(injectedStage, 'fallback'), 'fallback')
+
+  const mismatchedOrigin = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"execution","code":"central_computation_failed"}'
+  assert.equal(extractSharedError(mismatchedOrigin, 'fallback'), 'fallback')
+
+  assert.equal(
+    extractSharedError(`not-a-docker-timestamp ${valid}`, 'fallback'),
+    'fallback',
+  )
+})

--- a/desktopApp/electronApp/electron-builder.config.cjs
+++ b/desktopApp/electronApp/electron-builder.config.cjs
@@ -2,6 +2,7 @@ const packageJson = require('./package.json');
 module.exports = {
   appId: 'neuroflame',
   productName: 'NeuroFLAME',
+  electronVersion: packageJson.build.electronVersion,
   directories: {
     buildResources: 'assets',
     output: 'dist',
@@ -15,7 +16,7 @@ module.exports = {
   ],
   mac: {
     icon: 'img/icons/icon-osx.icns',
-    target: 'dmg',
+    target: ['dmg', 'zip'],
     category: 'public.app-category.education',
     hardenedRuntime: true,
     notarize: {

--- a/desktopApp/electronApp/package.json
+++ b/desktopApp/electronApp/package.json
@@ -16,13 +16,16 @@
     "start-configured": "npm run build && electron . --config=../../configs/electronApp1.json",
     "start-configured-2": "npm run build && electron . --config=../../configs/electronApp2.json",
     "start-configured-3": "npm run build && electron . --config=../../configs/electronApp3.json",
-    "test": "npm run build && playwright test"
+    "test": "npm run build && playwright test",
+    "test-unit": "npm run build && node --test tests/*.test.mjs",
+    "test-version-compatibility": "npm run build && node --test tests/versionCompatibility.test.mjs"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "edge-federated-client": "1.7.0",
+    "electron-updater": "6.6.2",
     "node-pty": "^1.0.0",
     "winston": "^3.13.1",
     "xterm": "^5.3.0",
@@ -32,6 +35,7 @@
     "@playwright/test": "^1.52.0",
     "@types/electron": "^1.6.10",
     "@types/node": "^20.17.57",
+    "@types/semver": "7.7.1",
     "buffer-from": "^1.1.2",
     "electron": "^30.5.1",
     "electron-builder": "^24.13.3",

--- a/desktopApp/electronApp/scripts/build.cjs
+++ b/desktopApp/electronApp/scripts/build.cjs
@@ -12,7 +12,7 @@ if (NODE_ENV === 'production' && DEPLOY) {
 } 
 
 const targets = new Map([
-  [Platform.MAC, new Map([[Arch.universal, ['dmg']]])],
+  [Platform.MAC, new Map([[Arch.universal, ['dmg', 'zip']]])],
   [Platform.WINDOWS, new Map([[Arch.x64, ['nsis']]])],
   [Platform.LINUX, new Map([[Arch.x64, ['AppImage']]])],
 ]);

--- a/desktopApp/electronApp/src/autoUpdate.ts
+++ b/desktopApp/electronApp/src/autoUpdate.ts
@@ -1,0 +1,132 @@
+import { constants, promises as fs } from 'fs'
+import path from 'path'
+import { app, BrowserWindow, dialog } from 'electron'
+import electronUpdater from 'electron-updater'
+import { logger } from './logger.js'
+import { autoUpdateEligibility } from './autoUpdatePolicy.js'
+
+const { autoUpdater } = electronUpdater
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+let initializationPromise: Promise<void> | null = null
+let installPromptShown = false
+
+function logUpdateError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error)
+  logger.error(`Automatic update error: ${message}`)
+}
+
+async function promptToInstall(
+  parentWindow: BrowserWindow | null,
+  version: string,
+): Promise<void> {
+  if (installPromptShown) return
+  installPromptShown = true
+
+  const options = {
+    type: 'info' as const,
+    title: 'NeuroFLAME update ready',
+    message: `NeuroFLAME ${version} has been downloaded.`,
+    detail: 'Restart NeuroFLAME now to install the update, or install it automatically when you next quit.',
+    buttons: ['Restart now', 'Later'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true,
+  }
+  const result = parentWindow
+    ? await dialog.showMessageBox(parentWindow, options)
+    : await dialog.showMessageBox(options)
+
+  if (result.response === 0) {
+    autoUpdater.quitAndInstall()
+  }
+}
+
+function registerUpdaterEvents(parentWindow: BrowserWindow | null): void {
+  autoUpdater.on('checking-for-update', () => {
+    logger.info('Checking for a NeuroFLAME update')
+  })
+  autoUpdater.on('update-available', (info) => {
+    logger.info(`NeuroFLAME update ${info.version} is available`)
+  })
+  autoUpdater.on('update-not-available', () => {
+    logger.info('NeuroFLAME is up to date')
+  })
+  autoUpdater.on('download-progress', (progress) => {
+    logger.info(
+      `Downloading NeuroFLAME update: ${progress.percent.toFixed(1)}%`,
+    )
+  })
+  autoUpdater.on('update-downloaded', (info) => {
+    logger.info(`NeuroFLAME update ${info.version} is ready to install`)
+    promptToInstall(parentWindow, info.version).catch(logUpdateError)
+  })
+  autoUpdater.on('error', logUpdateError)
+}
+
+async function appImageIsWritable(appImagePath: string): Promise<boolean> {
+  try {
+    await Promise.all([
+      fs.access(appImagePath, constants.W_OK),
+      fs.access(path.dirname(appImagePath), constants.W_OK),
+    ])
+    return true
+  } catch {
+    logger.warn(
+      `Automatic updates are disabled because the AppImage or its directory is not writable: ${appImagePath}`,
+    )
+    return false
+  }
+}
+
+async function checkForUpdates(): Promise<void> {
+  try {
+    await autoUpdater.checkForUpdates()
+  } catch (error) {
+    logUpdateError(error)
+  }
+}
+
+export function initializeAutoUpdates(
+  parentWindow: BrowserWindow | null,
+): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      const appImagePath = process.env.APPIMAGE
+      const eligibility = autoUpdateEligibility(
+        app.isPackaged,
+        process.platform,
+        appImagePath,
+      )
+      if (!eligibility.enabled) {
+        logger.info(
+          `Automatic updates are disabled for this launch: ${eligibility.reason}`,
+        )
+        return
+      }
+
+      if (
+        process.platform === 'linux' &&
+        appImagePath &&
+        !(await appImageIsWritable(appImagePath))
+      ) {
+        return
+      }
+
+      autoUpdater.autoDownload = true
+      autoUpdater.autoInstallOnAppQuit = true
+      registerUpdaterEvents(parentWindow)
+
+      checkForUpdates().catch(logUpdateError)
+      const timer = setInterval(
+        () => {
+          checkForUpdates().catch(logUpdateError)
+        },
+        UPDATE_CHECK_INTERVAL_MS,
+      )
+      timer.unref()
+    })()
+  }
+
+  return initializationPromise
+}

--- a/desktopApp/electronApp/src/autoUpdatePolicy.ts
+++ b/desktopApp/electronApp/src/autoUpdatePolicy.ts
@@ -1,0 +1,26 @@
+export type AutoUpdateEligibility =
+  | { enabled: true }
+  | {
+    enabled: false
+    reason: 'development' | 'linux-not-appimage' | 'unsupported-platform'
+  }
+
+export function autoUpdateEligibility(
+  isPackaged: boolean,
+  platform: NodeJS.Platform,
+  appImagePath?: string,
+): AutoUpdateEligibility {
+  if (!isPackaged) {
+    return { enabled: false, reason: 'development' }
+  }
+
+  if (platform === 'linux' && !appImagePath) {
+    return { enabled: false, reason: 'linux-not-appimage' }
+  }
+
+  if (!['darwin', 'linux', 'win32'].includes(platform)) {
+    return { enabled: false, reason: 'unsupported-platform' }
+  }
+
+  return { enabled: true }
+}

--- a/desktopApp/electronApp/src/main.ts
+++ b/desktopApp/electronApp/src/main.ts
@@ -1,5 +1,5 @@
 // main.ts
-import { app, BrowserWindow, ipcMain, dialog } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron'
 import { start as startEdgeFederatedClient } from 'edge-federated-client'
 import { logger, logToPath } from './logger.js'
 import { createMainWindow } from './window.js'
@@ -20,6 +20,12 @@ import {
   pullSingularityImage,
   checkSingularityImageExists,
 } from './singularityImageManager.js'
+import {
+  compareAppAndApiVersions,
+  CompatibilityStatus,
+  versionEndpoint,
+} from './versionCompatibility.js'
+import { initializeAutoUpdates } from './autoUpdate.js'
 
 app.setName('NeuroFLAME')
 
@@ -27,6 +33,34 @@ let mainWindow: BrowserWindow | null = null
 let terminalProcess: TerminalProcess | null = null
 let appInitializationPromise: Promise<void> | null = null
 let windowCreationPromise: Promise<void> | null = null
+let compatibilityStatus: CompatibilityStatus = {
+  status: 'compatible',
+  appVersion: app.getVersion(),
+}
+
+async function checkApiCompatibility(queryUrl: string): Promise<CompatibilityStatus> {
+  const appVersion = app.getVersion()
+
+  try {
+    const response = await fetch(versionEndpoint(queryUrl), {
+      signal: AbortSignal.timeout(5000),
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { status: 'serverUpdateRequired', appVersion }
+      }
+      return { status: 'compatible', appVersion }
+    }
+    const payload = await response.json() as { version?: unknown }
+    return compareAppAndApiVersions(appVersion, payload.version)
+  } catch (error) {
+    logger.warn('Unable to verify central API version; continuing normally', {
+      error,
+    })
+    return { status: 'compatible', appVersion }
+  }
+}
 
 // ---- Helpers: shell + env normalization ------------------------------------
 
@@ -189,7 +223,13 @@ function initializeApp(): Promise<void> {
       try {
         const config = await initializeConfig()
         logToPath(config.logPath as string)
-        if (config.startEdgeClientOnLaunch) {
+        compatibilityStatus = await checkApiCompatibility(
+          config.centralServerQueryUrl,
+        )
+        if (
+          compatibilityStatus.status === 'compatible' &&
+          config.startEdgeClientOnLaunch
+        ) {
           startEdgeFederatedClient(config.edgeClientConfig)
         }
       } catch (error) {
@@ -216,7 +256,7 @@ async function openMainWindow(): Promise<void> {
           const niiUrl = parsedUrl.searchParams.get('url')
           if (niiUrl) {
             window.webContents.executeJavaScript(
-              `window.dispatchEvent(new MessageEvent('message', { data: { type: 'view-nifti', url: ${JSON.stringify(niiUrl)} } }))`
+              `window.dispatchEvent(new MessageEvent('message', { data: { type: 'view-nifti', url: ${JSON.stringify(niiUrl)} } }))`,
             ).catch(() => {})
           }
           return { action: 'deny' }
@@ -252,6 +292,7 @@ async function openMainWindow(): Promise<void> {
 async function appOnReady(): Promise<void> {
   await initializeApp()
   await openMainWindow()
+  await initializeAutoUpdates(mainWindow)
 }
 
 // ---- Terminal IPC -----------------------------------------------------------
@@ -313,6 +354,10 @@ app.on('activate', () => {
 
 ipcMain.handle('getConfigPath', () => getConfigPath())
 ipcMain.handle('getConfig', getConfig)
+ipcMain.handle('getCompatibilityStatus', () => compatibilityStatus)
+ipcMain.handle('openLatestRelease', () =>
+  shell.openExternal('https://github.com/NeuroFlame/NeuroFLAME/releases/latest'),
+)
 ipcMain.handle('openConfig', openConfig)
 ipcMain.handle('saveConfig', async (_e, configString) => await saveConfig(configString))
 ipcMain.handle('applyDefaultConfig', applyDefaultConfig)

--- a/desktopApp/electronApp/src/preload.js
+++ b/desktopApp/electronApp/src/preload.js
@@ -2,6 +2,8 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('ElectronAPI', {
   getConfig: async () => ipcRenderer.invoke('getConfig'),
+  getCompatibilityStatus: async () => ipcRenderer.invoke('getCompatibilityStatus'),
+  openLatestRelease: async () => ipcRenderer.invoke('openLatestRelease'),
   openConfig: async () => ipcRenderer.invoke('openConfig'),
   applyDefaultConfig: async () => ipcRenderer.invoke('applyDefaultConfig'),
   saveConfig: async (config) => ipcRenderer.invoke('saveConfig', config),

--- a/desktopApp/electronApp/src/versionCompatibility.ts
+++ b/desktopApp/electronApp/src/versionCompatibility.ts
@@ -1,0 +1,47 @@
+export type CompatibilityStatus =
+  | { status: 'compatible'; appVersion: string; apiVersion?: string }
+  | {
+    status: 'appUpdateRequired' | 'serverUpdateRequired'
+    appVersion: string
+    apiVersion?: string
+  }
+
+function parseVersion(value: unknown): [number, number, number] | null {
+  if (typeof value !== 'string') return null
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value)
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null
+}
+
+export function versionEndpoint(graphqlUrl: string): string {
+  const endpoint = new URL(graphqlUrl)
+  endpoint.pathname = endpoint.pathname.replace(/\/graphql\/?$/, '/version')
+  endpoint.search = ''
+  endpoint.hash = ''
+  return endpoint.toString()
+}
+
+export function compareAppAndApiVersions(
+  appVersion: string,
+  apiVersion: unknown,
+): CompatibilityStatus {
+  const appParts = parseVersion(appVersion)
+  if (!appParts) {
+    return { status: 'appUpdateRequired', appVersion }
+  }
+  const apiParts = parseVersion(apiVersion)
+  if (!apiParts) {
+    return { status: 'serverUpdateRequired', appVersion }
+  }
+  const normalizedApiVersion = apiVersion as string
+  if (apiParts[0] === appParts[0] && apiParts[1] === appParts[1]) {
+    return { status: 'compatible', appVersion, apiVersion: normalizedApiVersion }
+  }
+  const appIsOlder =
+    appParts[0] < apiParts[0] ||
+    (appParts[0] === apiParts[0] && appParts[1] < apiParts[1])
+  return {
+    status: appIsOlder ? 'appUpdateRequired' : 'serverUpdateRequired',
+    appVersion,
+    apiVersion: normalizedApiVersion,
+  }
+}

--- a/desktopApp/electronApp/tests/autoUpdatePolicy.test.mjs
+++ b/desktopApp/electronApp/tests/autoUpdatePolicy.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { autoUpdateEligibility } from '../build/autoUpdatePolicy.js'
+
+test('updates are disabled for development builds', () => {
+  assert.deepEqual(autoUpdateEligibility(false, 'linux', '/tmp/app.AppImage'), {
+    enabled: false,
+    reason: 'development',
+  })
+})
+
+test('packaged Linux updates require an AppImage launch', () => {
+  assert.deepEqual(autoUpdateEligibility(true, 'linux'), {
+    enabled: false,
+    reason: 'linux-not-appimage',
+  })
+  assert.deepEqual(
+    autoUpdateEligibility(true, 'linux', '/opt/NeuroFlame.AppImage'),
+    { enabled: true },
+  )
+})
+
+test('packaged macOS and Windows builds can update', () => {
+  assert.deepEqual(autoUpdateEligibility(true, 'darwin'), { enabled: true })
+  assert.deepEqual(autoUpdateEligibility(true, 'win32'), { enabled: true })
+})
+
+test('unsupported packaged platforms do not attempt updates', () => {
+  assert.deepEqual(autoUpdateEligibility(true, 'freebsd'), {
+    enabled: false,
+    reason: 'unsupported-platform',
+  })
+})

--- a/desktopApp/electronApp/tests/versionCompatibility.test.mjs
+++ b/desktopApp/electronApp/tests/versionCompatibility.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  compareAppAndApiVersions,
+  versionEndpoint,
+} from '../build/versionCompatibility.js'
+
+test('patch releases remain compatible', () => {
+  assert.equal(compareAppAndApiVersions('0.8.0', '0.8.7').status, 'compatible')
+})
+
+test('a newer API requires a desktop update', () => {
+  assert.equal(
+    compareAppAndApiVersions('0.8.9', '0.9.0').status,
+    'appUpdateRequired',
+  )
+})
+
+test('an older or invalid API requires a server update', () => {
+  assert.equal(
+    compareAppAndApiVersions('0.9.0', '0.8.9').status,
+    'serverUpdateRequired',
+  )
+  assert.equal(
+    compareAppAndApiVersions('0.8.0', 'legacy').status,
+    'serverUpdateRequired',
+  )
+})
+
+test('the version endpoint follows a configured GraphQL path', () => {
+  assert.equal(
+    versionEndpoint('https://example.test/neuroflame/graphql'),
+    'https://example.test/neuroflame/version',
+  )
+})

--- a/desktopApp/reactApp/src/CompatibilityScreen.css
+++ b/desktopApp/reactApp/src/CompatibilityScreen.css
@@ -1,0 +1,32 @@
+.compatibility-screen {
+  align-items: center;
+  background: #f5f7fa;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.compatibility-card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgb(15 23 42 / 12%);
+  max-width: 520px;
+  padding: 40px;
+  width: 100%;
+}
+
+.compatibility-card h1 { margin-top: 0; }
+.compatibility-card dl { margin: 28px 0; }
+.compatibility-card dl div { display: flex; justify-content: space-between; }
+.compatibility-card dt { font-weight: 600; }
+.compatibility-card dd { margin: 0; }
+.compatibility-card button {
+  background: #175cd3;
+  border: 0;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+  font: inherit;
+  padding: 12px 18px;
+}

--- a/desktopApp/reactApp/src/CompatibilityScreen.tsx
+++ b/desktopApp/reactApp/src/CompatibilityScreen.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { CompatibilityStatus, electronApi } from './apis/electronApi/electronApi'
+import './CompatibilityScreen.css'
+
+export default function CompatibilityScreen({
+  compatibility,
+}: {
+  compatibility: CompatibilityStatus
+}) {
+  const appNeedsUpdate = compatibility.status === 'appUpdateRequired'
+  return (
+    <main className='compatibility-screen'>
+      <section className='compatibility-card'>
+        <h1>
+          {appNeedsUpdate
+            ? 'Update NeuroFLAME to continue'
+            : 'The NeuroFLAME server must be updated'}
+        </h1>
+        <p>
+          {appNeedsUpdate
+            ? 'This app is not compatible with the configured NeuroFLAME server.'
+            : 'Contact your NeuroFLAME administrator before starting a computation.'}
+        </p>
+        <dl>
+          <div><dt>Desktop app</dt><dd>{compatibility.appVersion}</dd></div>
+          <div><dt>Central API</dt><dd>{compatibility.apiVersion ?? 'Legacy version'}</dd></div>
+        </dl>
+        {appNeedsUpdate && (
+          <button type='button' onClick={() => electronApi.openLatestRelease()}>
+            Download latest NeuroFLAME
+          </button>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/desktopApp/reactApp/src/apis/edgeApi/getLocalComputationError.ts
+++ b/desktopApp/reactApp/src/apis/edgeApi/getLocalComputationError.ts
@@ -1,0 +1,36 @@
+import axios from 'axios'
+
+export const SHARED_SITE_FAILURE_MESSAGE =
+  'Site computation failed. Detailed error is available only to that participant.'
+
+export interface LocalComputationError {
+  origin?: string;
+  stage?: string;
+  scope?: string;
+  errorType?: string;
+  message: string;
+}
+
+interface GetLocalComputationErrorArgs {
+  edgeClientRunResultsUrl: string;
+  consortiumId: string;
+  runId: string;
+  participantId: string;
+}
+
+export const getLocalComputationError = async ({
+  edgeClientRunResultsUrl,
+  consortiumId,
+  runId,
+  participantId,
+}: GetLocalComputationErrorArgs): Promise<LocalComputationError | null> => {
+  const path = [consortiumId, runId, participantId]
+    .map(encodeURIComponent)
+    .join('/')
+  const response = await axios.get<LocalComputationError>(
+    `${edgeClientRunResultsUrl}/error/${path}`,
+    { validateStatus: (status) => status === 200 || status === 404 },
+  )
+
+  return response.status === 200 ? response.data : null
+}

--- a/desktopApp/reactApp/src/apis/electronApi/electronApi.tsx
+++ b/desktopApp/reactApp/src/apis/electronApi/electronApi.tsx
@@ -34,9 +34,17 @@ export interface EdgeClientLogsResponse {
   error?: string;
 }
 
+export type CompatibilityStatus = {
+  status: 'compatible' | 'appUpdateRequired' | 'serverUpdateRequired';
+  appVersion: string;
+  apiVersion?: string;
+}
+
 interface ElectronAPI {
   getConfigPath: () => Promise<string>;
   getConfig: () => Promise<Config>;
+  getCompatibilityStatus: () => Promise<CompatibilityStatus>;
+  openLatestRelease: () => Promise<void>;
   openConfig: () => Promise<void>;
   saveConfig: (configString: string) => Promise<void>;
   applyDefaultConfig: () => Promise<void>;
@@ -66,6 +74,8 @@ declare global {
 
 export const electronApi = {
   getConfig,
+  getCompatibilityStatus: window.ElectronAPI.getCompatibilityStatus,
+  openLatestRelease: window.ElectronAPI.openLatestRelease,
   openConfig,
   getConfigPath,
   saveConfig,

--- a/desktopApp/reactApp/src/index.tsx
+++ b/desktopApp/reactApp/src/index.tsx
@@ -13,6 +13,7 @@ import ApolloClientsProvider from './contexts/ApolloClientsProvider'
 import { HashRouter as Router } from 'react-router-dom'
 import { UserStateProvider } from './contexts/UserStateContext'
 import interceptExternalLinks from './utils/interceptExternalLinks'
+import CompatibilityScreen from './CompatibilityScreen'
 
 const startApp = async () => {
   console.log('Starting app...')
@@ -21,6 +22,7 @@ const startApp = async () => {
 
   // Attempt to get the configuration
   const config = await electronApi.getConfig()
+  const compatibility = await electronApi.getCompatibilityStatus()
 
   // Check if the root element exists
   const rootElement = document.getElementById('root')
@@ -34,6 +36,11 @@ const startApp = async () => {
   }
 
   const root = ReactDOM.createRoot(rootElement)
+
+  if (compatibility.status !== 'compatible') {
+    root.render(<CompatibilityScreen compatibility={compatibility} />)
+    return
+  }
 
   // Render the app, even if config is null (if config is essential, consider a loading screen)
   root.render(

--- a/desktopApp/reactApp/src/pages/RunDetails/RunDetails.tsx
+++ b/desktopApp/reactApp/src/pages/RunDetails/RunDetails.tsx
@@ -17,6 +17,7 @@ import ReactMarkdown from 'react-markdown'
 import { useCallback, useState } from 'react'
 import { useCentralApi } from '../../apis/centralApi/centralApi'
 import { useUserState } from '../../contexts/UserStateContext'
+import { SHARED_SITE_FAILURE_MESSAGE } from '../../apis/edgeApi/getLocalComputationError'
 
 function RunDeleteModal({
   open,
@@ -72,7 +73,7 @@ function RunDeleteModal({
 
 export function RunDetails() {
   const navigate = useNavigate()
-  const { runDetails, loading, error } = useRunDetails()
+  const { runDetails, loading, error, localComputationError } = useRunDetails()
   const { runDelete } = useCentralApi()
   const { userId } = useUserState()
 
@@ -200,7 +201,7 @@ export function RunDetails() {
               />
             </Grid>
             {/* Errors */}
-            {runDetails.runErrors.length > 0 && (
+            {(runDetails.runErrors.length > 0 || localComputationError) && (
               <Grid size={{ sm: 12 }}>
                 <Box p={2} borderRadius={2} marginBottom={0} bgcolor='white'>
                   <Typography variant='h6' gutterBottom>
@@ -209,9 +210,38 @@ export function RunDetails() {
                   {runDetails.runErrors.map((error, index) => (
                     <Typography key={index} variant='body2' color='error'>
                       {new Date(+error.timestamp).toLocaleString()}{' '}
-                      {error.user.username} - {error.message}
+                      {error.user.username} -{' '}
+                      {localComputationError &&
+                      error.user.id === userId &&
+                      error.message === SHARED_SITE_FAILURE_MESSAGE
+                        ? <>
+                            {localComputationError.scope && (
+                              <strong>[{localComputationError.scope}] </strong>
+                            )}
+                            {localComputationError.errorType && (
+                              <strong>{localComputationError.errorType}: </strong>
+                            )}
+                            {localComputationError.message}
+                          </>
+                        : error.message}
                     </Typography>
                   ))}
+                  {localComputationError &&
+                  !runDetails.runErrors.some((runError) =>
+                    runError.user.id === userId &&
+                    runError.message === SHARED_SITE_FAILURE_MESSAGE
+                  ) && (
+                    <Typography variant='body2' color='error'>
+                      Local computation -{' '}
+                      {localComputationError.scope && (
+                        <strong>[{localComputationError.scope}] </strong>
+                      )}
+                      {localComputationError.errorType && (
+                        <strong>{localComputationError.errorType}: </strong>
+                      )}
+                      {localComputationError.message}
+                    </Typography>
+                  )}
                 </Box>
               </Grid>
             )}

--- a/desktopApp/reactApp/src/pages/RunDetails/useRunDetails.tsx
+++ b/desktopApp/reactApp/src/pages/RunDetails/useRunDetails.tsx
@@ -5,9 +5,15 @@ import {
   QueryGetRunDetailsArgs,
   RunDetails as GeneratedRunDetails,
 } from '../../apis/centralApi/generated/graphql' // Import the generated types
+import { useUserState } from '../../contexts/UserStateContext'
+import {
+  getLocalComputationError,
+  LocalComputationError,
+} from '../../apis/edgeApi/getLocalComputationError'
 
 export function useRunDetails() {
   const { runId } = useParams<{ runId: string }>() // Extract runId from the route params
+  const { userId } = useUserState()
   const {
     getRunDetails,
     subscriptions: { runDetailsChanged },
@@ -17,6 +23,8 @@ export function useRunDetails() {
   const [runDetails, setRunDetails] = useState<GeneratedRunDetails | null>(null) // Use the generated RunDetails type
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
+  const [localComputationError, setLocalComputationError] =
+    useState<LocalComputationError | null>(null)
 
   // Function to fetch run details
   const fetchRunDetails = async () => {
@@ -55,10 +63,42 @@ export function useRunDetails() {
     }
   }, [runId]) // Re-run the effect when runId or functions change
 
+  useEffect(() => {
+    const consortiumId = runDetails?.consortium.id
+    if (!consortiumId || !runId || !userId) return
+
+    let cancelled = false
+    setLocalComputationError(null)
+
+    const fetchLocalComputationError = async () => {
+      try {
+        const { edgeClientRunResultsUrl } = await window.ElectronAPI.getConfig()
+        const localError = await getLocalComputationError({
+          edgeClientRunResultsUrl,
+          consortiumId,
+          runId,
+          participantId: userId,
+        })
+        if (!cancelled) setLocalComputationError(localError)
+      } catch (localErrorFetchFailure) {
+        console.warn(
+          'Failed to fetch the local computation error',
+          localErrorFetchFailure,
+        )
+      }
+    }
+
+    fetchLocalComputationError()
+    return () => {
+      cancelled = true
+    }
+  }, [runDetails?.consortium.id, runId, userId])
+
   // Return the necessary data and states to be consumed by the component
   return {
     runDetails,
     loading,
     error,
+    localComputationError,
   }
 }

--- a/desktopApp/reactApp/src/pages/RunResults/RunResults.tsx
+++ b/desktopApp/reactApp/src/pages/RunResults/RunResults.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Box, Button, Typography } from '@mui/material'
+import { Alert, AlertTitle, Box, Button, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
 import { useNavigate } from 'react-router-dom'
 import { useRunResults } from './useRunResults'
@@ -20,6 +20,7 @@ export default function RunResults() {
     fileList,
     loading,
     error,
+    localComputationError,
     frameSrc,
     setFrameSrc,
     indexSrc,
@@ -135,6 +136,20 @@ export default function RunResults() {
           </Box>
         </Box>
       </Grid>
+      {localComputationError && (
+        <Grid size={{ sm: 12 }}>
+          <Alert severity='error'>
+            <AlertTitle>Local computation failed</AlertTitle>
+            {localComputationError.scope && (
+              <strong>[{localComputationError.scope}] </strong>
+            )}
+            {localComputationError.errorType && (
+              <strong>{localComputationError.errorType}: </strong>
+            )}
+            {localComputationError.message}
+          </Alert>
+        </Grid>
+      )}
       <Grid size={filesPanelWidth} style={{ transition: 'width 0.5s' }}>
         <Box display={filesPanelShow}>
           <Typography variant='h6' style={{ marginTop: '2rem' }}>

--- a/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
+++ b/desktopApp/reactApp/src/pages/RunResults/useRunResults.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import axios from 'axios'
 import { useUserState } from '../../contexts/UserStateContext'
+import {
+  getLocalComputationError,
+  LocalComputationError,
+} from '../../apis/edgeApi/getLocalComputationError'
 
 export interface FileInfo {
   name: string;
@@ -21,6 +25,8 @@ export function useRunResults() {
   const [fileList, setFileList] = useState<FileInfo[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
+  const [localComputationError, setLocalComputationError] =
+    useState<LocalComputationError | null>(null)
   const [frameSrc, setFrameSrc] = useState<string | null>(null)
   const [indexSrc, setIndexSrc] = useState<string | null>(null)
   const [
@@ -84,7 +90,23 @@ export function useRunResults() {
     const fetchResultsFilesList = async () => {
       try {
         const basePath = `${consortiumId}/${runId}/${userId}`
-        const files = await fetchRecursive(basePath)
+        const [files, localError] = await Promise.all([
+          fetchRecursive(basePath),
+          getLocalComputationError({
+            edgeClientRunResultsUrl,
+            consortiumId,
+            runId,
+            participantId: userId,
+          }).catch((localErrorFetchFailure) => {
+            console.warn(
+              'Failed to fetch the local computation error',
+              localErrorFetchFailure,
+            )
+            return null
+          }),
+        ])
+
+        setLocalComputationError(localError)
 
         const indexFile = files.find((file) =>
           file.name === 'index.html' && file.url.endsWith('/index.html'),
@@ -130,6 +152,7 @@ export function useRunResults() {
     fileList,
     loading,
     error,
+    localComputationError,
     frameSrc,
     setFrameSrc,
     indexSrc,

--- a/docs/build-for-release.md
+++ b/docs/build-for-release.md
@@ -52,3 +52,21 @@ The distributable file is located at:
 desktopApp/electronApp/dist
 ```
 
+### Automatic update artifacts
+
+Production builds check the repository's latest GitHub Release at startup and
+every six hours. Updates download in the background, then NeuroFLAME prompts the
+user to restart. Choosing **Later** installs the downloaded update on the next
+normal quit.
+
+GitHub Releases must contain the platform package and its generated update
+metadata:
+
+- Linux: the AppImage and `latest-linux.yml`
+- Windows: the NSIS installer and `latest.yml`
+- macOS: the DMG, ZIP, and `latest-mac.yml`
+
+Linux auto-update works only when NeuroFLAME is launched from the AppImage and
+both the AppImage and its containing directory are writable by that user.
+Development, unpacked, system package, and read-only AppImage launches skip the
+automatic check; users can still install the latest release manually.

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -1,0 +1,20 @@
+# NeuroFLAME version compatibility
+
+NeuroFLAME checks two separate contracts.
+
+The Electron desktop and central API use their application release versions.
+Their semantic-version major and minor components must match; patch releases
+remain compatible. The central API exposes its version at `GET /version`. An
+explicit mismatch prevents the embedded edge client from starting. A newer API
+directs the user to the latest NeuroFLAME desktop release, while an older API
+must be updated by the server administrator. A network outage does not produce
+a separate version error screen.
+
+Computation images use the exact computation API version stored in OCI image
+metadata. Before provisioning, the central client pulls the configured image,
+validates its metadata, and resolves a registry digest. The central API stores
+that snapshot and sends the same digest to every participant. Docker clients
+inspect the digest's labels again; Singularity and Apptainer caches are built
+from and keyed by that digest. Images without the required metadata or with a
+different computation API or NVFlare version are rejected before run data is
+downloaded or mounted.

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -18,3 +18,12 @@ inspect the digest's labels again; Singularity and Apptainer caches are built
 from and keyed by that digest. Images without the required metadata or with a
 different computation API or NVFlare version are rejected before run data is
 downloaded or mounted.
+
+The development-only central launcher instead selects an already-built local
+Docker tag without pulling it. It validates the same metadata and pins the run
+to the content-addressed Docker image ID. Edge and vault Docker clients verify
+that exact ID and its labels before execution. This requires the local clients
+to share a Docker daemon; local image IDs are intentionally unsupported by the
+Singularity and Apptainer paths. Production startup defaults to registry
+resolution, and `COMPUTATION_IMAGE_MODE=registry node dev-start.js` can be used
+to exercise production resolution during development.

--- a/edgeFederatedClient/package.json
+++ b/edgeFederatedClient/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "build": "tsc",
+    "test": "npm run compile && node --test tests/sharedError.test.mjs",
     "start": "npm run compile && node ./dist/index.js $npm_config_path"
   },
   "author": "",

--- a/edgeFederatedClient/src/api/controllers/runResultsFilesController.ts
+++ b/edgeFederatedClient/src/api/controllers/runResultsFilesController.ts
@@ -14,6 +14,23 @@ interface FileInfo {
   url: string;
 }
 
+interface TerminalErrorMarker {
+  schema_version?: unknown;
+  origin?: unknown;
+  stage?: unknown;
+  scope?: unknown;
+  error_type?: unknown;
+  message?: unknown;
+}
+
+const MAX_ERROR_FIELD_LENGTH = 2000
+
+const cleanErrorField = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const cleaned = value.trim().slice(0, MAX_ERROR_FIELD_LENGTH)
+  return cleaned || undefined
+}
+
 const resolveResultsDirectory = (
   filesDirectory: string,
   consortiumId: string,
@@ -101,6 +118,48 @@ export const listRunFiles = async (req: Request, res: Response) => {
   } catch (error) {
     logger.error(`Error in listRunFiles: ${(error as Error).message}`)
     res.status(500).json({ error: 'Internal Server Error' })
+  }
+}
+
+export const getRunError = async (req: Request, res: Response) => {
+  try {
+    const { pathBaseDirectory: filesDirectory } = await getConfig()
+    const { consortiumId, runId, participantId: routeParticipantId } = req.params
+    const participantId = (
+      routeParticipantId ??
+      (req as any).user?.participantId ??
+      (req as any).user?.userId
+    ) as string | undefined
+    const resultsDirectory = resolveResultsDirectory(
+      filesDirectory,
+      consortiumId,
+      runId,
+      participantId,
+    )
+    const markerPath = path.join(resultsDirectory, '.neuroflame_error.json')
+
+    if (!fs.existsSync(markerPath)) {
+      return res.status(404).json({ error: 'No local computation error found' })
+    }
+
+    const marker = JSON.parse(
+      fs.readFileSync(markerPath, 'utf8'),
+    ) as TerminalErrorMarker
+    const message = cleanErrorField(marker.message)
+    if (!message) {
+      return res.status(422).json({ error: 'Invalid local computation error' })
+    }
+
+    return res.json({
+      origin: cleanErrorField(marker.origin),
+      stage: cleanErrorField(marker.stage),
+      scope: cleanErrorField(marker.scope),
+      errorType: cleanErrorField(marker.error_type),
+      message,
+    })
+  } catch (error) {
+    logger.error(`Error in getRunError: ${(error as Error).message}`)
+    return res.status(500).json({ error: 'Internal Server Error' })
   }
 }
 

--- a/edgeFederatedClient/src/api/routes/runResultsRoutes.ts
+++ b/edgeFederatedClient/src/api/routes/runResultsRoutes.ts
@@ -1,6 +1,7 @@
 // src/routes/runFilesRoutes.ts
 import { Router } from 'express'
 import {
+  getRunError,
   listRunFiles,
   serveRunFile,
   serveRunFolder,
@@ -9,6 +10,7 @@ import {
 const router = Router()
 
 // Define the routes
+router.get('/error/:consortiumId/:runId/:participantId', getRunError)
 router.get('/zip/:consortiumId/:runId/:participantId', serveRunFolder)
 router.get('/:consortiumId/:runId/:participantId/*', serveRunFile)
 router.get('/:consortiumId/:runId/:participantId', listRunFiles)

--- a/edgeFederatedClient/src/runCoordinator/computationImage.ts
+++ b/edgeFederatedClient/src/runCoordinator/computationImage.ts
@@ -1,0 +1,175 @@
+import Docker from 'dockerode'
+import { execFile, spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const docker = new Docker()
+
+export interface ComputationImageMetadata {
+  title: string
+  computationVersion: string
+  revision: string
+  source: string
+  computationApiVersion: string
+  boilerplateVersion: string
+  nvflareVersion: string
+}
+
+export interface ResolvedComputationImage {
+  sourceImage: string
+  reference: string
+  digest: string
+  metadata: ComputationImageMetadata
+}
+
+const LABELS: Record<keyof ComputationImageMetadata, string> = {
+  title: 'org.opencontainers.image.title',
+  computationVersion: 'org.opencontainers.image.version',
+  revision: 'org.opencontainers.image.revision',
+  source: 'org.opencontainers.image.source',
+  computationApiVersion: 'org.neuroflame.computation-api.version',
+  boilerplateVersion: 'org.neuroflame.boilerplate.version',
+  nvflareVersion: 'org.neuroflame.nvflare.version',
+}
+
+function validateResolvedImage(resolvedImage: ResolvedComputationImage): void {
+  if (!/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest)) {
+    throw new Error('Resolved computation image digest is invalid')
+  }
+  if (!resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)) {
+    throw new Error('Resolved computation image reference does not match its digest')
+  }
+}
+
+async function pullDockerImage(reference: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    docker.pull(
+      reference,
+      (
+        error: Error | null,
+        stream: NodeJS.ReadableStream | undefined,
+      ) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        if (!stream) {
+          reject(new Error(`Docker did not return a pull stream for ${reference}`))
+          return
+        }
+        docker.modem.followProgress(stream, (progressError) => {
+          if (progressError) {
+            reject(progressError)
+            return
+          }
+          resolve()
+        })
+      },
+    )
+  })
+}
+
+async function prepareDockerImage(
+  resolvedImage: ResolvedComputationImage,
+): Promise<string> {
+  let inspection: Docker.ImageInspectInfo
+  try {
+    await pullDockerImage(resolvedImage.reference)
+    inspection = await docker.getImage(resolvedImage.reference).inspect()
+  } catch (error) {
+    try {
+      inspection = await docker.getImage(resolvedImage.reference).inspect()
+    } catch {
+      throw error
+    }
+  }
+  const labels = inspection.Config?.Labels ?? {}
+  for (const [field, label] of Object.entries(LABELS) as Array<
+    [keyof ComputationImageMetadata, string]
+  >) {
+    if (labels[label] !== resolvedImage.metadata[field]) {
+      throw new Error(`Computation image label "${label}" does not match the run`)
+    }
+  }
+  return resolvedImage.reference
+}
+
+function getSingularityBinary(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('which', ['singularity'], (singularityError) => {
+      if (!singularityError) {
+        resolve('singularity')
+        return
+      }
+      execFile('which', ['apptainer'], (apptainerError) => {
+        if (!apptainerError) {
+          resolve('apptainer')
+          return
+        }
+        reject(new Error('Neither Singularity nor Apptainer is installed'))
+      })
+    })
+  })
+}
+
+async function prepareSingularityImage(
+  resolvedImage: ResolvedComputationImage,
+  baseDirectory: string,
+): Promise<string> {
+  const imageDirectory = path.join(baseDirectory, 'singularityImages')
+  await fs.mkdir(imageDirectory, { recursive: true, mode: 0o700 })
+  const pattern = resolvedImage.sourceImage
+    .replace(/:latest$/, '')
+    .replace(/[:@/]/g, '_')
+    .toLowerCase()
+  const imagePath = path.join(
+    imageDirectory,
+    `${pattern}-${resolvedImage.digest.slice('sha256:'.length, 19)}.sif`,
+  )
+  try {
+    await fs.access(imagePath)
+    return imagePath
+  } catch {
+    // Pull the exact content-addressed image below.
+  }
+
+  const temporaryPath = `${imagePath}.tmp`
+  await fs.rm(temporaryPath, { force: true })
+  const binary = await getSingularityBinary()
+  await new Promise<void>((resolve, reject) => {
+    const processHandle = spawn(binary, [
+      'pull',
+      temporaryPath,
+      `docker://${resolvedImage.reference}`,
+    ])
+    let stderr = ''
+    processHandle.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    processHandle.on('error', reject)
+    processHandle.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(stderr || `Singularity pull exited with code ${code}`))
+      }
+    })
+  })
+  await fs.rename(temporaryPath, imagePath)
+  return imagePath
+}
+
+export async function prepareComputationImage(
+  resolvedImage: ResolvedComputationImage,
+  containerService: string,
+  baseDirectory: string,
+): Promise<string> {
+  validateResolvedImage(resolvedImage)
+  if (containerService === 'docker') {
+    return prepareDockerImage(resolvedImage)
+  }
+  if (containerService === 'singularity') {
+    return prepareSingularityImage(resolvedImage, baseDirectory)
+  }
+  throw new Error(`Unsupported container service: ${containerService}`)
+}

--- a/edgeFederatedClient/src/runCoordinator/computationImage.ts
+++ b/edgeFederatedClient/src/runCoordinator/computationImage.ts
@@ -36,7 +36,10 @@ function validateResolvedImage(resolvedImage: ResolvedComputationImage): void {
   if (!/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest)) {
     throw new Error('Resolved computation image digest is invalid')
   }
-  if (!resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)) {
+  if (
+    resolvedImage.reference !== resolvedImage.digest &&
+    !resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+  ) {
     throw new Error('Resolved computation image reference does not match its digest')
   }
 }
@@ -73,14 +76,22 @@ async function prepareDockerImage(
   resolvedImage: ResolvedComputationImage,
 ): Promise<string> {
   let inspection: Docker.ImageInspectInfo
-  try {
-    await pullDockerImage(resolvedImage.reference)
+  const isLocalImage = resolvedImage.reference === resolvedImage.digest
+  if (isLocalImage) {
     inspection = await docker.getImage(resolvedImage.reference).inspect()
-  } catch (error) {
+    if (inspection.Id !== resolvedImage.digest) {
+      throw new Error('Local computation image ID does not match the run')
+    }
+  } else {
     try {
+      await pullDockerImage(resolvedImage.reference)
       inspection = await docker.getImage(resolvedImage.reference).inspect()
-    } catch {
-      throw error
+    } catch (error) {
+      try {
+        inspection = await docker.getImage(resolvedImage.reference).inspect()
+      } catch {
+        throw error
+      }
     }
   }
   const labels = inspection.Config?.Labels ?? {}
@@ -169,6 +180,11 @@ export async function prepareComputationImage(
     return prepareDockerImage(resolvedImage)
   }
   if (containerService === 'singularity') {
+    if (resolvedImage.reference === resolvedImage.digest) {
+      throw new Error(
+        'Local computation images require the Docker container service',
+      )
+    }
     return prepareSingularityImage(resolvedImage, baseDirectory)
   }
   throw new Error(`Unsupported container service: ${containerService}`)

--- a/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
+++ b/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
@@ -6,6 +6,7 @@ import { unzipFile } from './unzipFile.js'
 import fs from 'fs/promises'
 import { logger } from '../../../logger.js'
 import reportRunError from '../../report/reportRunError.js'
+import { prepareComputationImage } from '../../computationImage.js'
 
 export const RUN_START_SUBSCRIPTION = `
   subscription runStartSubscription {
@@ -14,6 +15,20 @@ export const RUN_START_SUBSCRIPTION = `
       runId
       participantId
       imageName
+      resolvedImage {
+        sourceImage
+        reference
+        digest
+        metadata {
+          title
+          computationVersion
+          revision
+          source
+          computationApiVersion
+          boilerplateVersion
+          nvflareVersion
+        }
+      }
       downloadUrl
       downloadToken
     }
@@ -31,24 +46,34 @@ export const runStartHandler = {
         consortiumId,
         runId,
         participantId,
-        imageName,
+        resolvedImage,
         downloadUrl,
         downloadToken,
       } = data.runStartEdge
 
       const config = await getConfig()
       const { pathBaseDirectory, containerService = 'docker' } = config
+      const runtimeImage = await prepareComputationImage(
+        resolvedImage,
+        containerService,
+        pathBaseDirectory,
+      )
 
       const consortiumPath = path.join(pathBaseDirectory, consortiumId)
       const runPath = path.join(consortiumPath, runId, participantId)
       const runKitPath = path.join(runPath, 'runKit')
       const resultsPath = path.join(runPath, 'results')
 
-      // Ensure all paths exist and are writable and executable
-      await fs.mkdir(consortiumPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(runPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(runKitPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(resultsPath, { recursive: true, mode: 0o777 })
+      // Keep run artifacts private to the federated-client service account.
+      for (const directory of [
+        consortiumPath,
+        runPath,
+        runKitPath,
+        resultsPath,
+      ]) {
+        await fs.mkdir(directory, { recursive: true, mode: 0o700 })
+        await fs.chmod(directory, 0o700)
+      }
 
       const mountConfigPath = path.join(consortiumPath, 'mount_config.json')
 
@@ -76,10 +101,12 @@ export const runStartHandler = {
         {
           hostDirectory: runKitPath,
           containerDirectory: '/workspace/runKit',
+          readOnly: false,
         },
         {
           hostDirectory: resultsPath,
           containerDirectory: '/workspace/output',
+          readOnly: false,
         },
       ]
 
@@ -92,6 +119,7 @@ export const runStartHandler = {
         directoriesToMount.push({
           hostDirectory: dataPath,
           containerDirectory: '/workspace/data',
+          readOnly: true,
         })
       } catch (e) {
         logger.error(`Failed to read or parse mount configuration: ${e}`)
@@ -101,10 +129,11 @@ export const runStartHandler = {
       // Launch the node
       await launchNode({
         containerService,
-        imageName,
+        imageName: runtimeImage,
         directoriesToMount,
         portBindings: [],
         commandsToRun: ['python', '/workspace/system/entry_edge.py'],
+        failureLogPath: path.join(resultsPath, 'failed-container.log'),
         onContainerExitError: async (containerId, error) => {
           logger.error(`[runStart] onContainerExitError called for container: ${containerId}`, { error })
           logger.info(`[runStart] runId: ${runId}`)

--- a/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
+++ b/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
@@ -7,6 +7,7 @@ import fs from 'fs/promises'
 import { logger } from '../../../logger.js'
 import reportRunError from '../../report/reportRunError.js'
 import { prepareComputationImage } from '../../computationImage.js'
+import { ensureLocalRuntimeError } from '../../terminalError.js'
 
 export const RUN_START_SUBSCRIPTION = `
   subscription runStartSubscription {
@@ -41,6 +42,7 @@ export const runStartHandler = {
   complete: () => logger.info('Run Start - Subscription completed'),
   next: async ({ data }: { data: any }) => {
     logger.info('Run Start - Received data')
+    let resultsPath: string | undefined
     try {
       const {
         consortiumId,
@@ -53,27 +55,29 @@ export const runStartHandler = {
 
       const config = await getConfig()
       const { pathBaseDirectory, containerService = 'docker' } = config
-      const runtimeImage = await prepareComputationImage(
-        resolvedImage,
-        containerService,
-        pathBaseDirectory,
-      )
 
       const consortiumPath = path.join(pathBaseDirectory, consortiumId)
       const runPath = path.join(consortiumPath, runId, participantId)
       const runKitPath = path.join(runPath, 'runKit')
-      const resultsPath = path.join(runPath, 'results')
+      const currentResultsPath = path.join(runPath, 'results')
+      resultsPath = currentResultsPath
 
       // Keep run artifacts private to the federated-client service account.
       for (const directory of [
         consortiumPath,
         runPath,
         runKitPath,
-        resultsPath,
+        currentResultsPath,
       ]) {
         await fs.mkdir(directory, { recursive: true, mode: 0o700 })
         await fs.chmod(directory, 0o700)
       }
+
+      const runtimeImage = await prepareComputationImage(
+        resolvedImage,
+        containerService,
+        pathBaseDirectory,
+      )
 
       const mountConfigPath = path.join(consortiumPath, 'mount_config.json')
 
@@ -104,7 +108,7 @@ export const runStartHandler = {
           readOnly: false,
         },
         {
-          hostDirectory: resultsPath,
+          hostDirectory: currentResultsPath,
           containerDirectory: '/workspace/output',
           readOnly: false,
         },
@@ -133,15 +137,21 @@ export const runStartHandler = {
         directoriesToMount,
         portBindings: [],
         commandsToRun: ['python', '/workspace/system/entry_edge.py'],
-        failureLogPath: path.join(resultsPath, 'failed-container.log'),
+        failureLogPath: path.join(currentResultsPath, 'failed-container.log'),
         onContainerExitError: async (containerId, error) => {
           logger.error(`[runStart] onContainerExitError called for container: ${containerId}`, { error })
           logger.info(`[runStart] runId: ${runId}`)
-          logger.info(`[runStart] About to call reportRunError with errorMessage: Error in container ${containerId}: ${error}`)
+          logger.info('[runStart] Reporting a site computation failure')
           try {
+            await ensureLocalRuntimeError(
+              currentResultsPath,
+              'container_runtime',
+              error,
+            )
             const result = await reportRunError({
               runId,
-              errorMessage: `Error in container ${containerId}: ${error}`,
+              errorMessage:
+                'Site computation failed. Detailed error is available in the participant\'s local run results.',
             })
             logger.info(`[runStart] reportRunError completed successfully, result: ${result}`)
           } catch (err) {
@@ -156,6 +166,20 @@ export const runStartHandler = {
       })
     } catch (error) {
       logger.error('Error in runStartHandler', { error })
+
+      if (resultsPath) {
+        try {
+          await ensureLocalRuntimeError(
+            resultsPath,
+            'run_startup',
+            (error as Error).message,
+          )
+        } catch (markerError) {
+          logger.error('Failed to record the local run error', {
+            error: markerError,
+          })
+        }
+      }
 
       await reportRunError({
         runId: data.runStartEdge.runId,

--- a/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/unzipFile.ts
+++ b/edgeFederatedClient/src/runCoordinator/eventHandlers/runStart/unzipFile.ts
@@ -14,6 +14,7 @@ type UnzipFileParams = {
 }
 
 async function setPermissions(dir: string, mode: number): Promise<void> {
+  await chmod(dir, mode)
   const files = await readdir(dir)
 
   for (const file of files) {
@@ -23,7 +24,7 @@ async function setPermissions(dir: string, mode: number): Promise<void> {
     if (fileStat.isDirectory()) {
       await setPermissions(filePath, mode)
     } else {
-      await chmod(filePath, mode)
+      await chmod(filePath, filePath.endsWith('.sh') ? 0o700 : 0o600)
     }
   }
 }
@@ -59,8 +60,8 @@ export async function unzipFile({
   }
 
   try {
-    await setPermissions(directory, 0o777)
-    logger.info(`Permissions set to 0o777 for all extracted files in: ${directory}`)
+    await setPermissions(directory, 0o700)
+    logger.info(`Restricted extracted run-kit permissions in: ${directory}`)
   } catch (err) {
     logger.error(`Error setting file permissions: ${(err as Error).message}`)
     throw err

--- a/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'fs'
 import * as path from 'path'
 import { logger } from '../../logger.js'
 import { getConfig } from '../../config/config.js'
+import { extractSharedError } from './sharedError.js'
 const docker = new Docker()
 
 const MAX_FAILURE_LOG_BYTES = 1024 * 1024
@@ -163,7 +164,10 @@ const attachDockerEventHandlers = async ({
       })
       await captureFailedContainerLogs(container, failureLogPath)
       if (onContainerExitError) {
-        await onContainerExitError(containerId, (waitError as Error).message)
+        await onContainerExitError(
+          containerId,
+          'Participant computation container could not be monitored',
+        )
       }
       return
     }
@@ -172,9 +176,13 @@ const attachDockerEventHandlers = async ({
       logger.error(
         `Container ${containerId} exited with error code ${statusCode}`,
       )
-      await captureFailedContainerLogs(container, failureLogPath)
+      const localLogs = await captureFailedContainerLogs(container, failureLogPath)
+      const sharedError = extractSharedError(
+        localLogs,
+        `Participant computation container exited with code ${statusCode}`,
+      )
       if (onContainerExitError) {
-        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+        await onContainerExitError(containerId, sharedError)
       }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
@@ -201,11 +209,7 @@ const attachDockerEventHandlers = async ({
 const captureFailedContainerLogs = async (
   container: ReturnType<typeof docker.getContainer>,
   failureLogPath?: string,
-): Promise<void> => {
-  if (!failureLogPath) {
-    return
-  }
-
+): Promise<string> => {
   try {
     const rawLogs = await container.logs({
       stdout: true,
@@ -213,12 +217,17 @@ const captureFailedContainerLogs = async (
       timestamps: true,
       tail: 10000,
     })
-    await writeFailureLog(failureLogPath, decodeDockerLogs(rawLogs))
-    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+    const decodedLogs = decodeDockerLogs(rawLogs)
+    if (failureLogPath) {
+      await writeFailureLog(failureLogPath, decodedLogs)
+      logger.info(`Saved failed-container logs to ${failureLogPath}`)
+    }
+    return decodedLogs
   } catch (logError) {
     logger.warn(`Could not save failed-container logs for ${container.id}`, {
       error: logError,
     })
+    return ''
   }
 }
 
@@ -450,13 +459,17 @@ const attachSingularityEventHandlers = ({
     }
 
     if (code !== 0) {
-      const errorMessage = capturedStderr || capturedStdout || `Exit Code: ${code}`
+      const localError = capturedStderr || capturedStdout || `Exit Code: ${code}`
+      const errorMessage = extractSharedError(
+        `${capturedStdout}\n${capturedStderr}`,
+        `Participant computation process exited with code ${code}`,
+      )
       logger.error(
         `Container ${containerId} exited with error code ${code}`,
       )
-      await captureFailedProcessLogs(failureLogPath, errorMessage)
+      await captureFailedProcessLogs(failureLogPath, localError)
       if (onContainerExitError) {
-        await onContainerExitError(containerId, `Exit Code: ${code}`)
+        await onContainerExitError(containerId, errorMessage)
       }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
@@ -475,7 +488,10 @@ const attachSingularityEventHandlers = ({
       error.stack || error.message,
     )
     if (onContainerExitError) {
-      await onContainerExitError(containerId, error.message)
+      await onContainerExitError(
+        containerId,
+        'Participant computation process could not be started',
+      )
     }
   }
 

--- a/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -6,20 +6,24 @@ import { logger } from '../../logger.js'
 import { getConfig } from '../../config/config.js'
 const docker = new Docker()
 
+const MAX_FAILURE_LOG_BYTES = 1024 * 1024
+
 interface LaunchNodeArgs {
   containerService: string
   imageName: string
   directoriesToMount: Array<{
     hostDirectory: string
     containerDirectory: string
+    readOnly?: boolean
   }>
   portBindings: Array<{
     hostPort: number
     containerPort: number
   }>
   commandsToRun: string[]
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }
 
 interface ExposedPorts {
@@ -36,6 +40,7 @@ export async function launchNode({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: LaunchNodeArgs) {
@@ -45,6 +50,7 @@ export async function launchNode({
       directoriesToMount,
       portBindings,
       commandsToRun,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -54,6 +60,7 @@ export async function launchNode({
       directoriesToMount,
       portBindings,
       commandsToRun,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -65,6 +72,7 @@ const launchDockerNode = async ({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: Omit<LaunchNodeArgs, 'containerService'>) => {
@@ -73,7 +81,8 @@ const launchDockerNode = async ({
   )
 
   const binds = directoriesToMount.map(
-    (mount) => `${mount.hostDirectory}:${mount.containerDirectory}`,
+    (mount) =>
+      `${mount.hostDirectory}:${mount.containerDirectory}:${mount.readOnly ? 'ro' : 'rw'}`,
   )
   const exposedPorts: ExposedPorts = {}
   const portBindingsFormatted: PortBindings = {}
@@ -87,6 +96,9 @@ const launchDockerNode = async ({
   try {
     await isDockerRunning()
     await doesImageExist(imageName)
+    if (failureLogPath) {
+      await fs.rm(failureLogPath, { force: true })
+    }
 
     // Create the container
     const container = await docker.createContainer({
@@ -95,6 +107,8 @@ const launchDockerNode = async ({
       ExposedPorts: exposedPorts,
       HostConfig: {
         Binds: binds,
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges:true'],
         PortBindings: portBindingsFormatted,
         NetworkMode: process.env.CI === 'true' ? 'ci-network' : 'bridge',
         ExtraHosts: process.env.CI === 'true'
@@ -110,6 +124,7 @@ const launchDockerNode = async ({
     // Add event handlers for the container
     attachDockerEventHandlers({
       containerId: container.id,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -126,32 +141,148 @@ const launchDockerNode = async ({
 
 const attachDockerEventHandlers = async ({
   containerId,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: {
   containerId: string
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }) => {
   const container = docker.getContainer(containerId)
 
   try {
-    const { StatusCode } = await container.wait()
-    if (StatusCode !== 0) {
+    let statusCode: number
+    try {
+      const waitResult = await container.wait()
+      statusCode = waitResult.StatusCode
+    } catch (waitError) {
+      logger.error(`Error waiting for container ${containerId}`, {
+        error: waitError,
+      })
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, (waitError as Error).message)
+      }
+      return
+    }
+
+    if (statusCode !== 0) {
       logger.error(
-        `Container ${containerId} exited with error code ${StatusCode}`,
+        `Container ${containerId} exited with error code ${statusCode}`,
       )
-      onContainerExitError &&
-        onContainerExitError(containerId, `Exit Code: ${StatusCode}`)
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+      }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
-      onContainerExitSuccess && onContainerExitSuccess(containerId)
+      if (onContainerExitSuccess) {
+        await onContainerExitSuccess(containerId)
+      }
     }
-  } catch (error) {
-    logger.error(`Error waiting for container ${containerId}`, { error })
-    onContainerExitError &&
-      onContainerExitError(containerId, (error as Error).message)
+  } catch (handlerError) {
+    logger.error(`Failed to handle exit for container ${containerId}`, {
+      error: handlerError,
+    })
+  } finally {
+    try {
+      await container.remove()
+      logger.info(`Removed completed container ${containerId}`)
+    } catch (removeError) {
+      logger.warn(`Failed to remove completed container ${containerId}`, {
+        error: removeError,
+      })
+    }
   }
+}
+
+const captureFailedContainerLogs = async (
+  container: ReturnType<typeof docker.getContainer>,
+  failureLogPath?: string,
+): Promise<void> => {
+  if (!failureLogPath) {
+    return
+  }
+
+  try {
+    const rawLogs = await container.logs({
+      stdout: true,
+      stderr: true,
+      timestamps: true,
+      tail: 10000,
+    })
+    await writeFailureLog(failureLogPath, decodeDockerLogs(rawLogs))
+    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+  } catch (logError) {
+    logger.warn(`Could not save failed-container logs for ${container.id}`, {
+      error: logError,
+    })
+  }
+}
+
+const writeFailureLog = async (
+  failureLogPath: string,
+  logContent: string,
+): Promise<void> => {
+  const logBuffer = Buffer.from(logContent, 'utf8')
+  const wasTruncated = logBuffer.length > MAX_FAILURE_LOG_BYTES
+  const retainedLogs = wasTruncated
+    ? logBuffer.subarray(logBuffer.length - MAX_FAILURE_LOG_BYTES)
+    : logBuffer
+  const prefix = wasTruncated
+    ? `[truncated to last ${MAX_FAILURE_LOG_BYTES} bytes]\n`
+    : ''
+
+  await fs.mkdir(path.dirname(failureLogPath), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await fs.writeFile(
+    failureLogPath,
+    Buffer.concat([Buffer.from(prefix, 'utf8'), retainedLogs]),
+    { mode: 0o600 },
+  )
+  await fs.chmod(failureLogPath, 0o600)
+}
+
+const captureFailedProcessLogs = async (
+  failureLogPath: string | undefined,
+  logContent: string,
+): Promise<void> => {
+  if (!failureLogPath) {
+    return
+  }
+  try {
+    await writeFailureLog(failureLogPath, logContent)
+    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+  } catch (logError) {
+    logger.warn(`Could not save failed-container logs to ${failureLogPath}`, {
+      error: logError,
+    })
+  }
+}
+
+const decodeDockerLogs = (rawLogs: Buffer): string => {
+  const chunks: Buffer[] = []
+  let offset = 0
+
+  while (offset + 8 <= rawLogs.length) {
+    const streamType = rawLogs[offset]
+    const payloadLength = rawLogs.readUInt32BE(offset + 4)
+    const payloadStart = offset + 8
+    const payloadEnd = payloadStart + payloadLength
+    if (![0, 1, 2].includes(streamType) || payloadEnd > rawLogs.length) {
+      return rawLogs.toString('utf8')
+    }
+    chunks.push(rawLogs.subarray(payloadStart, payloadEnd))
+    offset = payloadEnd
+  }
+
+  return offset === rawLogs.length && chunks.length > 0
+    ? Buffer.concat(chunks).toString('utf8')
+    : rawLogs.toString('utf8')
 }
 
 const isDockerRunning = async () => {
@@ -187,6 +318,7 @@ const launchSingularityNode = async ({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: Omit<LaunchNodeArgs, 'containerService'>) => {
@@ -197,10 +329,14 @@ const launchSingularityNode = async ({
   try {
     const singularityBinary = await detectSingularityOrApptainer()
     const imagePath = await findSingularityImage(imageName)
+    if (failureLogPath) {
+      await fs.rm(failureLogPath, { force: true })
+    }
 
     // Build mount bindings for Singularity (-B flag)
     const bindMounts: string[] = directoriesToMount.map(
-      (mount) => `${mount.hostDirectory}:${mount.containerDirectory}:rw`,
+      (mount) =>
+        `${mount.hostDirectory}:${mount.containerDirectory}:${mount.readOnly ? 'ro' : 'rw'}`,
     )
 
     // Add /tmp mount for compatibility
@@ -259,25 +395,6 @@ const launchSingularityNode = async ({
 
     logger.info(`Singularity container started successfully: ${containerId}`)
 
-    // Handle stdout and stderr
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let stdout = ''
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let stderr = ''
-
-    instanceProcess.stdout?.on('data', (data: Buffer) => {
-      const output = data.toString()
-      stdout += output
-      logger.info(`Singularity Container [${containerId}] stdout: ${output.trim()}`)
-    })
-
-    instanceProcess.stderr?.on('data', (data: Buffer) => {
-      const output = data.toString()
-      stderr += output
-      // Singularity often outputs info to stderr, so log as info unless it's an error
-      logger.info(`Singularity Container [${containerId}] stderr: ${output.trim()}`)
-    })
-
     // Process error handling is now in the exitPromise
 
     // Set up exit handlers (similar to Docker's attachDockerEventHandlers)
@@ -285,6 +402,7 @@ const launchSingularityNode = async ({
     attachSingularityEventHandlers({
       instanceProcess,
       containerId,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -298,16 +416,18 @@ const launchSingularityNode = async ({
   }
 }
 
-const attachSingularityEventHandlers = async ({
+const attachSingularityEventHandlers = ({
   instanceProcess,
   containerId,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: {
   instanceProcess: ReturnType<typeof spawn>
   containerId: string
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }) => {
   // Track output as it comes in (similar to how Docker captures logs)
   let capturedStdout = ''
@@ -321,12 +441,16 @@ const attachSingularityEventHandlers = async ({
     capturedStderr += data.toString()
   })
 
-  // Wait for process to exit (similar to Docker's container.wait())
-  instanceProcess.on('close', (code: number | null) => {
+  const handleClose = async (code: number | null): Promise<void> => {
     if (code === null) {
       logger.error(`Container ${containerId} exited with null code`)
-      onContainerExitError &&
-        onContainerExitError(containerId, 'Process exited with null code')
+      await captureFailedProcessLogs(
+        failureLogPath,
+        capturedStderr || capturedStdout || 'Process exited with null code',
+      )
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, 'Process exited with null code')
+      }
       return
     }
 
@@ -335,22 +459,45 @@ const attachSingularityEventHandlers = async ({
       logger.error(
         `Container ${containerId} exited with error code ${code}`,
       )
-      logger.error(`Error output: ${errorMessage}`)
-      onContainerExitError &&
-        onContainerExitError(containerId, errorMessage)
+      await captureFailedProcessLogs(failureLogPath, errorMessage)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, `Exit Code: ${code}`)
+      }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
-      onContainerExitSuccess && onContainerExitSuccess(containerId)
+      if (onContainerExitSuccess) {
+        await onContainerExitSuccess(containerId)
+      }
     }
-  })
+  }
 
-  // Handle process errors
-  instanceProcess.on('error', (error: Error) => {
+  const handleError = async (error: Error): Promise<void> => {
     logger.error(
       `Failed to start Singularity container: ${error.message}`,
     )
-    onContainerExitError &&
-      onContainerExitError(containerId, error.message)
+    await captureFailedProcessLogs(
+      failureLogPath,
+      error.stack || error.message,
+    )
+    if (onContainerExitError) {
+      await onContainerExitError(containerId, error.message)
+    }
+  }
+
+  instanceProcess.on('close', (code: number | null) => {
+    void handleClose(code).catch((handlerError) => {
+      logger.error(`Failed to handle exit for container ${containerId}`, {
+        error: handlerError,
+      })
+    })
+  })
+
+  instanceProcess.on('error', (error: Error) => {
+    void handleError(error).catch((handlerError) => {
+      logger.error(`Failed to handle process error for container ${containerId}`, {
+        error: handlerError,
+      })
+    })
   })
 }
 

--- a/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/edgeFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -297,18 +297,13 @@ const isDockerRunning = async () => {
 
 const doesImageExist = async (imageName: string) => {
   try {
-    const images = await docker.listImages({
-      filters: { reference: [imageName] },
-    })
-    if (images.length === 0) {
-      throw new Error(
-        `Image "${imageName}" does not exist. Please pull the image or verify its name.`,
-      )
-    }
+    await docker.getImage(imageName).inspect()
   } catch (error) {
+    const detail = (error as { statusCode?: number }).statusCode === 404
+      ? `Image "${imageName}" does not exist. Please pull the image or verify its name.`
+      : (error as Error).message
     throw new Error(
-      `Failed to check existence of image "${imageName}": ${(error as Error).message
-      }`,
+      `Failed to check existence of image "${imageName}": ${detail}`,
     )
   }
 }
@@ -485,7 +480,7 @@ const attachSingularityEventHandlers = ({
   }
 
   instanceProcess.on('close', (code: number | null) => {
-    void handleClose(code).catch((handlerError) => {
+    handleClose(code).catch((handlerError) => {
       logger.error(`Failed to handle exit for container ${containerId}`, {
         error: handlerError,
       })
@@ -493,7 +488,7 @@ const attachSingularityEventHandlers = ({
   })
 
   instanceProcess.on('error', (error: Error) => {
-    void handleError(error).catch((handlerError) => {
+    handleError(error).catch((handlerError) => {
       logger.error(`Failed to handle process error for container ${containerId}`, {
         error: handlerError,
       })

--- a/edgeFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
+++ b/edgeFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
@@ -1,0 +1,66 @@
+const SHARED_ERROR_PREFIX = 'NEUROFLAME_SHARED_ERROR:'
+const DOCKER_TIMESTAMP_PREFIX = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{1,9})?Z /
+
+const ERROR_MESSAGES = {
+  central_computation_failed: {
+    startup: 'Central computation failed during startup',
+    execution: 'Central computation failed during execution',
+    aggregation: 'Central computation failed during aggregation',
+    transfer: 'Central computation failed during artifact transfer',
+  },
+  participant_computation_failed: {
+    startup: 'Participant computation failed during startup',
+    execution: 'Participant computation failed during execution',
+    aggregation: 'Participant computation failed during aggregation',
+    transfer: 'Participant computation failed during artifact transfer',
+  },
+} as const
+
+type ErrorCode = keyof typeof ERROR_MESSAGES
+type ErrorStage = keyof (typeof ERROR_MESSAGES)[ErrorCode]
+
+interface SharedErrorEnvelope {
+  schema_version: 1
+  origin: 'central' | 'site'
+  stage: ErrorStage
+  code: ErrorCode
+}
+
+const isSharedErrorEnvelope = (value: unknown): value is SharedErrorEnvelope => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  if (candidate.schema_version !== 1) return false
+  if (candidate.origin !== 'central' && candidate.origin !== 'site') return false
+  if (
+    candidate.code !== 'central_computation_failed'
+    && candidate.code !== 'participant_computation_failed'
+  ) return false
+  if (
+    candidate.stage !== 'startup'
+    && candidate.stage !== 'execution'
+    && candidate.stage !== 'aggregation'
+    && candidate.stage !== 'transfer'
+  ) return false
+  return (
+    (candidate.origin === 'central' && candidate.code === 'central_computation_failed')
+    || (candidate.origin === 'site' && candidate.code === 'participant_computation_failed')
+  )
+}
+
+export const extractSharedError = (logs: string, fallback: string): string => {
+  const encodedLines = logs
+    .split(/\r?\n/)
+    .map((line) => line.replace(DOCKER_TIMESTAMP_PREFIX, ''))
+    .filter((line) => line.startsWith(SHARED_ERROR_PREFIX))
+  for (const line of encodedLines) {
+    try {
+      const envelope: unknown = JSON.parse(line.slice(SHARED_ERROR_PREFIX.length))
+      if (isSharedErrorEnvelope(envelope)) {
+        return ERROR_MESSAGES[envelope.code][envelope.stage]
+      }
+    } catch {
+      // Ignore malformed computation output and use an orchestrator-owned fallback.
+    }
+  }
+  return fallback
+}

--- a/edgeFederatedClient/src/runCoordinator/report/reportRunError.ts
+++ b/edgeFederatedClient/src/runCoordinator/report/reportRunError.ts
@@ -21,8 +21,8 @@ interface ReportRunErrorResponse {
 
 // GraphQL mutation
 const REPORT_RUN_ERROR_MUTATION = `
-  mutation reportRunError($runId: String!, $errorMessage: String!) {
-    reportRunError(runId: $runId, errorMessage: $errorMessage)
+  mutation reportRunError($runId: String!, $errorMessage: String!, $redactErrorDetails: Boolean!) {
+    reportRunError(runId: $runId, errorMessage: $errorMessage, redactErrorDetails: $redactErrorDetails)
   }
 `
 
@@ -56,7 +56,7 @@ export default async function reportRunError({
       },
       body: JSON.stringify({
         query: REPORT_RUN_ERROR_MUTATION,
-        variables: { runId, errorMessage },
+        variables: { runId, errorMessage, redactErrorDetails: true },
       }),
     })
     logger.info(`[reportRunError] Received response status: ${response.status} ${response.statusText}`)

--- a/edgeFederatedClient/src/runCoordinator/terminalError.ts
+++ b/edgeFederatedClient/src/runCoordinator/terminalError.ts
@@ -1,0 +1,40 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const TERMINAL_ERROR_FILE = '.neuroflame_error.json'
+const MAX_LOCAL_ERROR_LENGTH = 4000
+
+export const ensureLocalRuntimeError = async (
+  outputDirectory: string,
+  stage: string,
+  message: string,
+): Promise<void> => {
+  const markerPath = path.join(outputDirectory, TERMINAL_ERROR_FILE)
+  try {
+    await fs.access(markerPath)
+    return
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  await fs.mkdir(outputDirectory, { recursive: true, mode: 0o700 })
+  await fs.writeFile(
+    markerPath,
+    JSON.stringify(
+      {
+        schema_version: 1,
+        origin: 'site',
+        stage,
+        scope: 'site runtime',
+        error_type: 'RuntimeError',
+        message: message.trim().slice(0, MAX_LOCAL_ERROR_LENGTH),
+        traceback: '',
+      },
+      null,
+      2,
+    ),
+    { encoding: 'utf8', mode: 0o600 },
+  )
+}

--- a/edgeFederatedClient/tests/sharedError.test.mjs
+++ b/edgeFederatedClient/tests/sharedError.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { extractSharedError } from '../dist/runCoordinator/nodeManager/sharedError.js'
+
+test('accepts only allowlisted shared-error envelopes', () => {
+  const valid = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"transfer","code":"participant_computation_failed"}'
+  assert.equal(
+    extractSharedError(valid, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+  assert.equal(
+    extractSharedError(`ordinary log line\n2026-08-06T23:59:00.123456789Z ${valid}`, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+
+  const arbitrary = 'NEUROFLAME_SHARED_ERROR:"patient subject-123"'
+  assert.equal(extractSharedError(arbitrary, 'fallback'), 'fallback')
+
+  const injectedStage = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"subject-123","code":"participant_computation_failed"}'
+  assert.equal(extractSharedError(injectedStage, 'fallback'), 'fallback')
+
+  const mismatchedOrigin = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"execution","code":"central_computation_failed"}'
+  assert.equal(extractSharedError(mismatchedOrigin, 'fallback'), 'fallback')
+
+  assert.equal(
+    extractSharedError(`not-a-docker-timestamp ${valid}`, 'fallback'),
+    'fallback',
+  )
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
             "license": "ISC",
             "dependencies": {
                 "edge-federated-client": "1.7.0",
+                "electron-updater": "6.6.2",
                 "node-pty": "^1.0.0",
                 "winston": "^3.13.1",
                 "xterm": "^5.3.0",
@@ -31,6 +32,7 @@
                 "@playwright/test": "^1.52.0",
                 "@types/electron": "^1.6.10",
                 "@types/node": "^20.17.57",
+                "@types/semver": "7.7.1",
                 "buffer-from": "^1.1.2",
                 "electron": "^30.5.1",
                 "electron-builder": "^24.13.3",
@@ -1479,11 +1481,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "desktopApp/electronApp/node_modules/lazy-val": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
-        },
         "desktopApp/electronApp/node_modules/loader-runner": {
             "version": "4.3.0",
             "dev": true,
@@ -1630,11 +1627,6 @@
             "dependencies": {
                 "truncate-utf8-bytes": "^1.0.0"
             }
-        },
-        "desktopApp/electronApp/node_modules/sax": {
-            "version": "1.4.1",
-            "dev": true,
-            "license": "ISC"
         },
         "desktopApp/electronApp/node_modules/schema-utils": {
             "version": "3.3.0",
@@ -3691,6 +3683,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/send": {
             "version": "0.17.5",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -4932,6 +4931,36 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/builder-util-runtime": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
+            "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/builder-util-runtime/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5803,6 +5832,85 @@
             },
             "engines": {
                 "node": ">= 12.20.55"
+            }
+        },
+        "node_modules/electron-updater": {
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
+            "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
+            "license": "MIT",
+            "dependencies": {
+                "builder-util-runtime": "9.3.1",
+                "fs-extra": "^10.1.0",
+                "js-yaml": "^4.1.0",
+                "lazy-val": "^1.0.5",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isequal": "^4.5.0",
+                "semver": "^7.6.3",
+                "tiny-typed-emitter": "^2.1.0"
+            }
+        },
+        "node_modules/electron-updater/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
+        "node_modules/electron-updater/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/electron-updater/node_modules/js-yaml": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/electron-updater/node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/electron-updater/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/electron/node_modules/@types/node": {
@@ -8306,6 +8414,12 @@
             "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
             "license": "MIT"
         },
+        "node_modules/lazy-val": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+            "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+            "license": "MIT"
+        },
         "node_modules/lazystream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -8392,6 +8506,12 @@
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "license": "MIT"
         },
+        "node_modules/lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+            "license": "MIT"
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8402,6 +8522,13 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
@@ -10043,6 +10170,15 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
+        "node_modules/sax": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
         "node_modules/semver": {
             "version": "7.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -10806,6 +10942,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
             "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+            "license": "MIT"
+        },
+        "node_modules/tiny-typed-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
             "license": "MIT"
         },
         "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "scripts": {
         "db:start": "docker compose --env-file _devCentralDatabase/.env -f _devCentralDatabase/docker-compose.yaml up -d",
         "lint": "eslint .",
-        "release": "bash ./scripts/release.sh"
+        "release": "bash ./scripts/release.sh",
+        "check-app-api-version": "node ./scripts/check-app-api-compatibility.mjs"
     }
 }

--- a/scripts/check-app-api-compatibility.mjs
+++ b/scripts/check-app-api-compatibility.mjs
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises'
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf8'))
+const parse = (version, label) => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) throw new Error(`${label} has invalid version ${version}`)
+  return match.slice(1).map(Number)
+}
+
+const electronPackage = await readJson('desktopApp/electronApp/package.json')
+const apiPackage = await readJson('centralApi/package.json')
+const versionsSource = await readFile('centralApi/src/versions.ts', 'utf8')
+const declaredApiVersion = /APPLICATION_API_VERSION = '([^']+)'/.exec(
+  versionsSource,
+)?.[1]
+
+if (declaredApiVersion !== apiPackage.version) {
+  throw new Error(
+    `Central API package version ${apiPackage.version} does not match endpoint version ${declaredApiVersion}`,
+  )
+}
+
+const [appMajor, appMinor] = parse(electronPackage.version, 'Electron app')
+const [apiMajor, apiMinor] = parse(apiPackage.version, 'Central API')
+if (appMajor !== apiMajor || appMinor !== apiMinor) {
+  throw new Error(
+    `Electron ${electronPackage.version} is incompatible with central API ${apiPackage.version}`,
+  )
+}
+
+console.log(
+  `Electron ${electronPackage.version} and central API ${apiPackage.version} are compatible`,
+)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,6 +123,7 @@ done
 check_cmd npm
 check_cmd npx
 check_cmd git
+npm run check-app-api-version
 
 if [ "$ALLOW_DIRTY" != true ] && [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   echo "Tracked files are not clean. Commit/stash changes or rerun with --allow-dirty."

--- a/vaultFederatedClient/package.json
+++ b/vaultFederatedClient/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "compile": "tsc",
+    "test": "npm run compile && node --test tests/sharedError.test.mjs",
     "start": "npm run compile && node ./dist/cli.js start",
     "start-configured": "npm run compile && node ./dist/cli.js start",
     "prepack": "npm run clean && npm run compile"

--- a/vaultFederatedClient/src/imageManager.ts
+++ b/vaultFederatedClient/src/imageManager.ts
@@ -22,6 +22,33 @@ type ContainerService = 'docker' | 'singularity'
 type DockerStatus = 'missing' | 'pulling' | 'ready' | 'failed'
 type SingularityStatus = 'missing' | 'pending' | 'running' | 'ready' | 'failed'
 
+export interface ComputationImageMetadata {
+  title: string
+  computationVersion: string
+  revision: string
+  source: string
+  computationApiVersion: string
+  boilerplateVersion: string
+  nvflareVersion: string
+}
+
+export interface ResolvedComputationImage {
+  sourceImage: string
+  reference: string
+  digest: string
+  metadata: ComputationImageMetadata
+}
+
+const COMPUTATION_LABELS: Record<keyof ComputationImageMetadata, string> = {
+  title: 'org.opencontainers.image.title',
+  computationVersion: 'org.opencontainers.image.version',
+  revision: 'org.opencontainers.image.revision',
+  source: 'org.opencontainers.image.source',
+  computationApiVersion: 'org.neuroflame.computation-api.version',
+  boilerplateVersion: 'org.neuroflame.boilerplate.version',
+  nvflareVersion: 'org.neuroflame.nvflare.version',
+}
+
 interface DockerCacheState {
   localDigest?: string
   status?: DockerStatus
@@ -729,14 +756,18 @@ async function refreshDockerCache(imageName: string, remoteDigest?: string): Pro
     if (!localDigest) {
       entry.docker.status = 'pulling'
       await persistCacheState()
-      void pullDockerImageIfNeeded(imageName, remoteDigest)
+      pullDockerImageIfNeeded(imageName, remoteDigest).catch((error) => {
+        logger.warn(`Background Docker pull failed for ${imageName}`, { error })
+      })
       return
     }
 
     if (remoteDigest && localDigest !== remoteDigest) {
       entry.docker.status = 'pulling'
       await persistCacheState()
-      void pullDockerImageIfNeeded(imageName, remoteDigest)
+      pullDockerImageIfNeeded(imageName, remoteDigest).catch((error) => {
+        logger.warn(`Background Docker refresh failed for ${imageName}`, { error })
+      })
       return
     }
 
@@ -783,7 +814,9 @@ async function refreshSingularityCache(
       ? 'running'
       : 'pending'
     await persistCacheState()
-    void queueSingularityBuild(imageName, remoteDigest)
+    queueSingularityBuild(imageName, remoteDigest).catch((error) => {
+      logger.warn(`Background Singularity build failed for ${imageName}`, { error })
+    })
   } catch (error) {
     entry.singularity.status = 'failed'
     entry.singularity.lastError = (error as Error).message
@@ -851,7 +884,8 @@ async function refreshTrackedImages(): Promise<void> {
 
 async function ensureDockerImageReady(imageName: string): Promise<void> {
   const entry = ensureImageEntry(imageName)
-  const remoteDigest = await updateRemoteDigest(imageName)
+  const requestedDigest = /@(sha256:[0-9a-f]{64})$/.exec(imageName)?.[1]
+  const remoteDigest = requestedDigest ?? await updateRemoteDigest(imageName)
   const localDigest = await getLocalDockerDigest(imageName)
   entry.docker.localDigest = localDigest
 
@@ -862,30 +896,16 @@ async function ensureDockerImageReady(imageName: string): Promise<void> {
     return
   }
 
-  try {
-    const updatedLocalDigest = await pullDockerImageIfNeeded(imageName, remoteDigest)
-    entry.docker.localDigest = updatedLocalDigest
-    entry.docker.status = updatedLocalDigest ? 'ready' : 'missing'
-    await persistCacheState()
-  } catch (error) {
-    if (localDigest) {
-      logger.warn(
-        `Docker refresh failed for ${imageName}, continuing with existing local image`,
-        { error },
-      )
-      entry.docker.status = 'ready'
-      entry.docker.lastError = (error as Error).message
-      await persistCacheState()
-      return
-    }
-
-    throw error
-  }
+  const updatedLocalDigest = await pullDockerImageIfNeeded(imageName, remoteDigest)
+  entry.docker.localDigest = updatedLocalDigest
+  entry.docker.status = updatedLocalDigest ? 'ready' : 'missing'
+  await persistCacheState()
 }
 
 async function ensureSingularityImageReady(imageName: string): Promise<void> {
   const entry = ensureImageEntry(imageName)
-  const remoteDigest = await updateRemoteDigest(imageName)
+  const requestedDigest = /@(sha256:[0-9a-f]{64})$/.exec(imageName)?.[1]
+  const remoteDigest = requestedDigest ?? await updateRemoteDigest(imageName)
 
   if (remoteDigest) {
     const targetHash = digestToShortHash(remoteDigest)
@@ -936,6 +956,32 @@ export async function ensureImageReadyForRun(
   await ensureSingularityImageReady(imageName)
 }
 
+export async function prepareResolvedComputationImage(
+  resolvedImage: ResolvedComputationImage,
+  containerService: ContainerService,
+): Promise<string> {
+  if (
+    !/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest) ||
+    !resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+  ) {
+    throw new Error('Resolved computation image reference is invalid')
+  }
+
+  await ensureImageReadyForRun(resolvedImage.reference, containerService)
+  if (containerService === 'docker') {
+    const inspection = await docker.getImage(resolvedImage.reference).inspect()
+    const labels = inspection.Config?.Labels ?? {}
+    for (const [field, label] of Object.entries(COMPUTATION_LABELS) as Array<
+      [keyof ComputationImageMetadata, string]
+    >) {
+      if (labels[label] !== resolvedImage.metadata[field]) {
+        throw new Error(`Computation image label "${label}" does not match the run`)
+      }
+    }
+  }
+  return resolvedImage.reference
+}
+
 export async function startImageManager(): Promise<void> {
   if (refreshInterval) {
     return
@@ -945,7 +991,7 @@ export async function startImageManager(): Promise<void> {
   await refreshTrackedImages()
 
   refreshInterval = setInterval(() => {
-    void refreshTrackedImages().catch((error) => {
+    refreshTrackedImages().catch((error) => {
       logger.error('Periodic image cache refresh failed', { error })
     })
   }, IMAGE_REFRESH_INTERVAL_MS)

--- a/vaultFederatedClient/src/imageManager.ts
+++ b/vaultFederatedClient/src/imageManager.ts
@@ -962,14 +962,29 @@ export async function prepareResolvedComputationImage(
 ): Promise<string> {
   if (
     !/^sha256:[0-9a-f]{64}$/.test(resolvedImage.digest) ||
-    !resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+    !(
+      resolvedImage.reference === resolvedImage.digest ||
+      resolvedImage.reference.endsWith(`@${resolvedImage.digest}`)
+    )
   ) {
     throw new Error('Resolved computation image reference is invalid')
   }
 
-  await ensureImageReadyForRun(resolvedImage.reference, containerService)
+  const isLocalImage = resolvedImage.reference === resolvedImage.digest
+  if (isLocalImage && containerService !== 'docker') {
+    throw new Error(
+      'Local computation images require the Docker container service',
+    )
+  }
+
+  if (!isLocalImage) {
+    await ensureImageReadyForRun(resolvedImage.reference, containerService)
+  }
   if (containerService === 'docker') {
     const inspection = await docker.getImage(resolvedImage.reference).inspect()
+    if (isLocalImage && inspection.Id !== resolvedImage.digest) {
+      throw new Error('Local computation image ID does not match the run')
+    }
     const labels = inspection.Config?.Labels ?? {}
     for (const [field, label] of Object.entries(COMPUTATION_LABELS) as Array<
       [keyof ComputationImageMetadata, string]

--- a/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
+++ b/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
@@ -62,7 +62,9 @@ export const runStartHandler = {
         downloadToken,
       } = data.runStartEdge
 
-      await registerTrackedImage(resolvedImage.reference)
+      if (resolvedImage.reference !== resolvedImage.digest) {
+        await registerTrackedImage(resolvedImage.reference)
+      }
       const runtimeImage = await prepareResolvedComputationImage(
         resolvedImage,
         VAULT_CONTAINER_SERVICE,

--- a/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
+++ b/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/runStart.ts
@@ -3,7 +3,7 @@ import {
   VAULT_CONTAINER_SERVICE,
 } from '../../../config.js'
 import {
-  ensureImageReadyForRun,
+  prepareResolvedComputationImage,
   registerTrackedImage,
 } from '../../../imageManager.js'
 import { resolveDatasetPathForVault } from '../../../vaultConfigManager.js'
@@ -24,6 +24,20 @@ export const RUN_START_SUBSCRIPTION = `
       vaultId
       computationId
       imageName
+      resolvedImage {
+        sourceImage
+        reference
+        digest
+        metadata {
+          title
+          computationVersion
+          revision
+          source
+          computationApiVersion
+          boilerplateVersion
+          nvflareVersion
+        }
+      }
       downloadUrl
       downloadToken
     }
@@ -43,24 +57,32 @@ export const runStartHandler = {
         participantId,
         vaultId,
         computationId,
-        imageName,
+        resolvedImage,
         downloadUrl,
         downloadToken,
       } = data.runStartEdge
 
-      await registerTrackedImage(imageName)
-      await ensureImageReadyForRun(imageName, VAULT_CONTAINER_SERVICE)
+      await registerTrackedImage(resolvedImage.reference)
+      const runtimeImage = await prepareResolvedComputationImage(
+        resolvedImage,
+        VAULT_CONTAINER_SERVICE,
+      )
 
       const consortiumPath = path.join(VAULT_BASE_DIR, consortiumId)
       const runPath = path.join(consortiumPath, runId, participantId)
       const runKitPath = path.join(runPath, 'runKit')
       const resultsPath = path.join(runPath, 'results')
 
-      // Ensure all paths exist and are writable and executable
-      await fs.mkdir(consortiumPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(runPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(runKitPath, { recursive: true, mode: 0o777 })
-      await fs.mkdir(resultsPath, { recursive: true, mode: 0o777 })
+      // Keep run artifacts private to the federated-client service account.
+      for (const directory of [
+        consortiumPath,
+        runPath,
+        runKitPath,
+        resultsPath,
+      ]) {
+        await fs.mkdir(directory, { recursive: true, mode: 0o700 })
+        await fs.chmod(directory, 0o700)
+      }
 
       // Download the runkit to the appropriate directory
       await downloadFile({
@@ -86,10 +108,12 @@ export const runStartHandler = {
         {
           hostDirectory: runKitPath,
           containerDirectory: '/workspace/runKit',
+          readOnly: false,
         },
         {
           hostDirectory: resultsPath,
           containerDirectory: '/workspace/output',
+          readOnly: false,
         },
       ]
 
@@ -101,20 +125,22 @@ export const runStartHandler = {
       directoriesToMount.push({
         hostDirectory: datasetPath,
         containerDirectory: '/workspace/data',
+        readOnly: true,
       })
 
       // Launch the node
       await launchNode({
         containerService: VAULT_CONTAINER_SERVICE,
-        imageName,
+        imageName: runtimeImage,
         runId,
         consortiumId,
         directoriesToMount,
         portBindings: [],
         commandsToRun: ['python', '/workspace/system/entry_edge.py'],
+        failureLogPath: path.join(resultsPath, 'failed-container.log'),
         onContainerExitError: async (containerId, error) => {
           logger.error(`Error in container: ${containerId}`, { error })
-          reportRunError({
+          await reportRunError({
             runId,
             errorMessage: `Error in container: ${containerId}`,
           })

--- a/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/unzipFile.ts
+++ b/vaultFederatedClient/src/runCoordinator/eventHandlers/runStart/unzipFile.ts
@@ -14,6 +14,7 @@ type UnzipFileParams = {
 }
 
 async function setPermissions(dir: string, mode: number): Promise<void> {
+  await chmod(dir, mode)
   const files = await readdir(dir)
 
   for (const file of files) {
@@ -23,7 +24,7 @@ async function setPermissions(dir: string, mode: number): Promise<void> {
     if (fileStat.isDirectory()) {
       await setPermissions(filePath, mode)
     } else {
-      await chmod(filePath, mode)
+      await chmod(filePath, filePath.endsWith('.sh') ? 0o700 : 0o600)
     }
   }
 }
@@ -59,8 +60,8 @@ export async function unzipFile({
   }
 
   try {
-    await setPermissions(directory, 0o777)
-    logger.info(`Permissions set to 0o777 for all extracted files in: ${directory}`)
+    await setPermissions(directory, 0o700)
+    logger.info(`Restricted extracted run-kit permissions in: ${directory}`)
   } catch (err) {
     logger.error(`Error setting file permissions: ${(err as Error).message}`)
     throw err

--- a/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'fs'
 import * as path from 'path'
 import { logger } from '../../logger.js'
 import { VAULT_BASE_DIR } from '../../config.js'
+import { extractSharedError } from './sharedError.js'
 const docker = new Docker()
 
 const MAX_FAILURE_LOG_BYTES = 1024 * 1024
@@ -195,7 +196,10 @@ const attachDockerEventHandlers = async ({
       })
       await captureFailedContainerLogs(container, failureLogPath)
       if (onContainerExitError) {
-        await onContainerExitError(containerId, (waitError as Error).message)
+        await onContainerExitError(
+          containerId,
+          'Participant computation container could not be monitored',
+        )
       }
       return
     }
@@ -208,9 +212,13 @@ const attachDockerEventHandlers = async ({
       logger.error(
         `Container ${containerId} exited with error code ${statusCode}`,
       )
-      await captureFailedContainerLogs(container, failureLogPath)
+      const localLogs = await captureFailedContainerLogs(container, failureLogPath)
+      const sharedError = extractSharedError(
+        localLogs,
+        `Participant computation container exited with code ${statusCode}`,
+      )
       if (onContainerExitError) {
-        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+        await onContainerExitError(containerId, sharedError)
       }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
@@ -239,11 +247,7 @@ const attachDockerEventHandlers = async ({
 const captureFailedContainerLogs = async (
   container: ReturnType<typeof docker.getContainer>,
   failureLogPath?: string,
-): Promise<void> => {
-  if (!failureLogPath) {
-    return
-  }
-
+): Promise<string> => {
   try {
     const rawLogs = await container.logs({
       stdout: true,
@@ -251,12 +255,17 @@ const captureFailedContainerLogs = async (
       timestamps: true,
       tail: 10000,
     })
-    await writeFailureLog(failureLogPath, decodeDockerLogs(rawLogs))
-    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+    const decodedLogs = decodeDockerLogs(rawLogs)
+    if (failureLogPath) {
+      await writeFailureLog(failureLogPath, decodedLogs)
+      logger.info(`Saved failed-container logs to ${failureLogPath}`)
+    }
+    return decodedLogs
   } catch (logError) {
     logger.warn(`Could not save failed-container logs for ${container.id}`, {
       error: logError,
     })
+    return ''
   }
 }
 
@@ -500,13 +509,17 @@ const attachSingularityEventHandlers = ({
     }
 
     if (code !== 0) {
-      const errorMessage = capturedStderr || capturedStdout || `Exit Code: ${code}`
+      const localError = capturedStderr || capturedStdout || `Exit Code: ${code}`
+      const errorMessage = extractSharedError(
+        `${capturedStdout}\n${capturedStderr}`,
+        `Participant computation process exited with code ${code}`,
+      )
       logger.error(
         `Container ${containerId} exited with error code ${code}`,
       )
-      await captureFailedProcessLogs(failureLogPath, errorMessage)
+      await captureFailedProcessLogs(failureLogPath, localError)
       if (onContainerExitError) {
-        await onContainerExitError(containerId, `Exit Code: ${code}`)
+        await onContainerExitError(containerId, errorMessage)
       }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
@@ -526,7 +539,10 @@ const attachSingularityEventHandlers = ({
       error.stack || error.message,
     )
     if (onContainerExitError) {
-      await onContainerExitError(containerId, error.message)
+      await onContainerExitError(
+        containerId,
+        'Participant computation process could not be started',
+      )
     }
   }
 

--- a/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -347,19 +347,13 @@ const isDockerRunning = async () => {
 
 const doesImageExist = async (imageName: string) => {
   try {
-    const images = await docker.listImages({
-      filters: { reference: [imageName] },
-    })
-    if (images.length === 0) {
-      throw new Error(
-        `Image "${imageName}" does not exist. Please pull the image or verify its name.`,
-      )
-    }
+    await docker.getImage(imageName).inspect()
   } catch (error) {
+    const detail = (error as { statusCode?: number }).statusCode === 404
+      ? `Image "${imageName}" does not exist. Please pull the image or verify its name.`
+      : (error as Error).message
     throw new Error(
-      `Failed to check existence of image "${imageName}": ${
-        (error as Error).message
-      }`,
+      `Failed to check existence of image "${imageName}": ${detail}`,
     )
   }
 }
@@ -537,7 +531,7 @@ const attachSingularityEventHandlers = ({
   }
 
   instanceProcess.on('close', (code: number | null) => {
-    void handleClose(code).catch((handlerError) => {
+    handleClose(code).catch((handlerError) => {
       logger.error(`Failed to handle exit for container ${containerId}`, {
         error: handlerError,
       })
@@ -545,7 +539,7 @@ const attachSingularityEventHandlers = ({
   })
 
   instanceProcess.on('error', (error: Error) => {
-    void handleError(error).catch((handlerError) => {
+    handleError(error).catch((handlerError) => {
       logger.error(`Failed to handle process error for container ${containerId}`, {
         error: handlerError,
       })

--- a/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
+++ b/vaultFederatedClient/src/runCoordinator/nodeManager/launchNode.ts
@@ -6,6 +6,8 @@ import { logger } from '../../logger.js'
 import { VAULT_BASE_DIR } from '../../config.js'
 const docker = new Docker()
 
+const MAX_FAILURE_LOG_BYTES = 1024 * 1024
+
 interface LaunchNodeArgs {
   containerService: string
   imageName: string
@@ -14,14 +16,16 @@ interface LaunchNodeArgs {
   directoriesToMount: Array<{
     hostDirectory: string
     containerDirectory: string
+    readOnly?: boolean
   }>
   portBindings: Array<{
     hostPort: number
     containerPort: number
   }>
   commandsToRun: string[]
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }
 
 // Track running containers for graceful shutdown and heartbeat reporting
@@ -51,6 +55,7 @@ export async function launchNode({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: LaunchNodeArgs) {
@@ -62,6 +67,7 @@ export async function launchNode({
       directoriesToMount,
       portBindings,
       commandsToRun,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -73,6 +79,7 @@ export async function launchNode({
       directoriesToMount,
       portBindings,
       commandsToRun,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -90,6 +97,7 @@ const launchDockerNode = async ({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: Omit<LaunchNodeArgs, 'containerService'>) => {
@@ -98,7 +106,8 @@ const launchDockerNode = async ({
   )
 
   const binds = directoriesToMount.map(
-    (mount) => `${mount.hostDirectory}:${mount.containerDirectory}`,
+    (mount) =>
+      `${mount.hostDirectory}:${mount.containerDirectory}:${mount.readOnly ? 'ro' : 'rw'}`,
   )
   const exposedPorts: ExposedPorts = {}
   const portBindingsFormatted: PortBindings = {}
@@ -112,6 +121,9 @@ const launchDockerNode = async ({
   try {
     await isDockerRunning()
     await doesImageExist(imageName)
+    if (failureLogPath) {
+      await removePreviousFailureLog(failureLogPath)
+    }
 
     // Create the container
     const container = await docker.createContainer({
@@ -120,6 +132,8 @@ const launchDockerNode = async ({
       ExposedPorts: exposedPorts,
       HostConfig: {
         Binds: binds,
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges:true'],
         PortBindings: portBindingsFormatted,
       },
     })
@@ -141,6 +155,7 @@ const launchDockerNode = async ({
     // Add event handlers for the container
     attachDockerEventHandlers({
       containerId: container.id,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -157,39 +172,167 @@ const launchDockerNode = async ({
 
 const attachDockerEventHandlers = async ({
   containerId,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: {
   containerId: string
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }) => {
   const container = docker.getContainer(containerId)
 
   try {
-    const { StatusCode } = await container.wait()
+    let statusCode: number
+    try {
+      const waitResult = await container.wait()
+      statusCode = waitResult.StatusCode
+    } catch (waitError) {
+      runningContainers.delete(containerId)
+      logger.error(`Error waiting for container ${containerId}`, {
+        error: waitError,
+      })
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, (waitError as Error).message)
+      }
+      return
+    }
 
     // Remove from tracking
     runningContainers.delete(containerId)
     logger.info(`Container ${containerId} removed from tracking`)
 
-    if (StatusCode !== 0) {
+    if (statusCode !== 0) {
       logger.error(
-        `Container ${containerId} exited with error code ${StatusCode}`,
+        `Container ${containerId} exited with error code ${statusCode}`,
       )
-      onContainerExitError &&
-        onContainerExitError(containerId, `Exit Code: ${StatusCode}`)
+      await captureFailedContainerLogs(container, failureLogPath)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, `Exit Code: ${statusCode}`)
+      }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
-      onContainerExitSuccess && onContainerExitSuccess(containerId)
+      if (onContainerExitSuccess) {
+        await onContainerExitSuccess(containerId)
+      }
     }
-  } catch (error) {
+  } catch (handlerError) {
     // Remove from tracking on error too
     runningContainers.delete(containerId)
-    logger.error(`Error waiting for container ${containerId}`, { error })
-    onContainerExitError &&
-      onContainerExitError(containerId, (error as Error).message)
+    logger.error(`Failed to handle exit for container ${containerId}`, {
+      error: handlerError,
+    })
+  } finally {
+    try {
+      await container.remove()
+      logger.info(`Removed completed container ${containerId}`)
+    } catch (removeError) {
+      logger.warn(`Failed to remove completed container ${containerId}`, {
+        error: removeError,
+      })
+    }
   }
+}
+
+const captureFailedContainerLogs = async (
+  container: ReturnType<typeof docker.getContainer>,
+  failureLogPath?: string,
+): Promise<void> => {
+  if (!failureLogPath) {
+    return
+  }
+
+  try {
+    const rawLogs = await container.logs({
+      stdout: true,
+      stderr: true,
+      timestamps: true,
+      tail: 10000,
+    })
+    await writeFailureLog(failureLogPath, decodeDockerLogs(rawLogs))
+    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+  } catch (logError) {
+    logger.warn(`Could not save failed-container logs for ${container.id}`, {
+      error: logError,
+    })
+  }
+}
+
+const removePreviousFailureLog = async (
+  failureLogPath: string,
+): Promise<void> => {
+  try {
+    await fs.unlink(failureLogPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+const writeFailureLog = async (
+  failureLogPath: string,
+  logContent: string,
+): Promise<void> => {
+  const logBuffer = Buffer.from(logContent, 'utf8')
+  const wasTruncated = logBuffer.length > MAX_FAILURE_LOG_BYTES
+  const retainedLogs = wasTruncated
+    ? logBuffer.subarray(logBuffer.length - MAX_FAILURE_LOG_BYTES)
+    : logBuffer
+  const prefix = wasTruncated
+    ? `[truncated to last ${MAX_FAILURE_LOG_BYTES} bytes]\n`
+    : ''
+
+  await fs.mkdir(path.dirname(failureLogPath), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await fs.writeFile(
+    failureLogPath,
+    Buffer.concat([Buffer.from(prefix, 'utf8'), retainedLogs]),
+    { mode: 0o600 },
+  )
+  await fs.chmod(failureLogPath, 0o600)
+}
+
+const captureFailedProcessLogs = async (
+  failureLogPath: string | undefined,
+  logContent: string,
+): Promise<void> => {
+  if (!failureLogPath) {
+    return
+  }
+  try {
+    await writeFailureLog(failureLogPath, logContent)
+    logger.info(`Saved failed-container logs to ${failureLogPath}`)
+  } catch (logError) {
+    logger.warn(`Could not save failed-container logs to ${failureLogPath}`, {
+      error: logError,
+    })
+  }
+}
+
+const decodeDockerLogs = (rawLogs: Buffer): string => {
+  const chunks: Buffer[] = []
+  let offset = 0
+
+  while (offset + 8 <= rawLogs.length) {
+    const streamType = rawLogs[offset]
+    const payloadLength = rawLogs.readUInt32BE(offset + 4)
+    const payloadStart = offset + 8
+    const payloadEnd = payloadStart + payloadLength
+    if (![0, 1, 2].includes(streamType) || payloadEnd > rawLogs.length) {
+      return rawLogs.toString('utf8')
+    }
+    chunks.push(rawLogs.subarray(payloadStart, payloadEnd))
+    offset = payloadEnd
+  }
+
+  return offset === rawLogs.length && chunks.length > 0
+    ? Buffer.concat(chunks).toString('utf8')
+    : rawLogs.toString('utf8')
 }
 
 const isDockerRunning = async () => {
@@ -228,6 +371,7 @@ const launchSingularityNode = async ({
   directoriesToMount,
   portBindings,
   commandsToRun,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: Omit<LaunchNodeArgs, 'containerService'>) => {
@@ -238,9 +382,13 @@ const launchSingularityNode = async ({
   try {
     const singularityBinary = detectSingularityOrApptainer()
     const imagePath = await findSingularityImage(imageName)
+    if (failureLogPath) {
+      await removePreviousFailureLog(failureLogPath)
+    }
 
     const bindMounts: string[] = directoriesToMount.map(
-      (mount) => `${mount.hostDirectory}:${mount.containerDirectory}:rw`,
+      (mount) =>
+        `${mount.hostDirectory}:${mount.containerDirectory}:${mount.readOnly ? 'ro' : 'rw'}`,
     )
 
     const envVars: string[] = []
@@ -300,19 +448,10 @@ const launchSingularityNode = async ({
       `Tracking singularity process ${containerId} for run ${runId} in consortium ${consortiumId}`,
     )
 
-    instanceProcess.stdout?.on('data', (data: Buffer) => {
-      const output = data.toString()
-      logger.info(`Singularity Container [${containerId}] stdout: ${output.trim()}`)
-    })
-
-    instanceProcess.stderr?.on('data', (data: Buffer) => {
-      const output = data.toString()
-      logger.info(`Singularity Container [${containerId}] stderr: ${output.trim()}`)
-    })
-
     attachSingularityEventHandlers({
       instanceProcess,
       containerId,
+      failureLogPath,
       onContainerExitSuccess,
       onContainerExitError,
     })
@@ -329,13 +468,15 @@ const launchSingularityNode = async ({
 const attachSingularityEventHandlers = ({
   instanceProcess,
   containerId,
+  failureLogPath,
   onContainerExitSuccess,
   onContainerExitError,
 }: {
   instanceProcess: ReturnType<typeof spawn>
   containerId: string
-  onContainerExitSuccess?: (containerId: string) => void
-  onContainerExitError?: (containerId: string, error: string) => void
+  failureLogPath?: string
+  onContainerExitSuccess?: (containerId: string) => void | Promise<unknown>
+  onContainerExitError?: (containerId: string, error: string) => void | Promise<unknown>
 }) => {
   let capturedStdout = ''
   let capturedStderr = ''
@@ -348,14 +489,19 @@ const attachSingularityEventHandlers = ({
     capturedStderr += data.toString()
   })
 
-  instanceProcess.on('close', (code: number | null) => {
+  const handleClose = async (code: number | null): Promise<void> => {
     runningContainers.delete(containerId)
     logger.info(`Container ${containerId} removed from tracking`)
 
     if (code === null) {
       logger.error(`Container ${containerId} exited with null code`)
-      onContainerExitError &&
-        onContainerExitError(containerId, 'Process exited with null code')
+      await captureFailedProcessLogs(
+        failureLogPath,
+        capturedStderr || capturedStdout || 'Process exited with null code',
+      )
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, 'Process exited with null code')
+      }
       return
     }
 
@@ -364,22 +510,46 @@ const attachSingularityEventHandlers = ({
       logger.error(
         `Container ${containerId} exited with error code ${code}`,
       )
-      logger.error(`Error output: ${errorMessage}`)
-      onContainerExitError &&
-        onContainerExitError(containerId, errorMessage)
+      await captureFailedProcessLogs(failureLogPath, errorMessage)
+      if (onContainerExitError) {
+        await onContainerExitError(containerId, `Exit Code: ${code}`)
+      }
     } else {
       logger.info(`Container ${containerId} exited successfully.`)
-      onContainerExitSuccess && onContainerExitSuccess(containerId)
+      if (onContainerExitSuccess) {
+        await onContainerExitSuccess(containerId)
+      }
     }
-  })
+  }
 
-  instanceProcess.on('error', (error: Error) => {
+  const handleError = async (error: Error): Promise<void> => {
     runningContainers.delete(containerId)
     logger.error(
       `Failed to start Singularity container: ${error.message}`,
     )
-    onContainerExitError &&
-      onContainerExitError(containerId, error.message)
+    await captureFailedProcessLogs(
+      failureLogPath,
+      error.stack || error.message,
+    )
+    if (onContainerExitError) {
+      await onContainerExitError(containerId, error.message)
+    }
+  }
+
+  instanceProcess.on('close', (code: number | null) => {
+    void handleClose(code).catch((handlerError) => {
+      logger.error(`Failed to handle exit for container ${containerId}`, {
+        error: handlerError,
+      })
+    })
+  })
+
+  instanceProcess.on('error', (error: Error) => {
+    void handleError(error).catch((handlerError) => {
+      logger.error(`Failed to handle process error for container ${containerId}`, {
+        error: handlerError,
+      })
+    })
   })
 }
 

--- a/vaultFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
+++ b/vaultFederatedClient/src/runCoordinator/nodeManager/sharedError.ts
@@ -1,0 +1,66 @@
+const SHARED_ERROR_PREFIX = 'NEUROFLAME_SHARED_ERROR:'
+const DOCKER_TIMESTAMP_PREFIX = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{1,9})?Z /
+
+const ERROR_MESSAGES = {
+  central_computation_failed: {
+    startup: 'Central computation failed during startup',
+    execution: 'Central computation failed during execution',
+    aggregation: 'Central computation failed during aggregation',
+    transfer: 'Central computation failed during artifact transfer',
+  },
+  participant_computation_failed: {
+    startup: 'Participant computation failed during startup',
+    execution: 'Participant computation failed during execution',
+    aggregation: 'Participant computation failed during aggregation',
+    transfer: 'Participant computation failed during artifact transfer',
+  },
+} as const
+
+type ErrorCode = keyof typeof ERROR_MESSAGES
+type ErrorStage = keyof (typeof ERROR_MESSAGES)[ErrorCode]
+
+interface SharedErrorEnvelope {
+  schema_version: 1
+  origin: 'central' | 'site'
+  stage: ErrorStage
+  code: ErrorCode
+}
+
+const isSharedErrorEnvelope = (value: unknown): value is SharedErrorEnvelope => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  if (candidate.schema_version !== 1) return false
+  if (candidate.origin !== 'central' && candidate.origin !== 'site') return false
+  if (
+    candidate.code !== 'central_computation_failed'
+    && candidate.code !== 'participant_computation_failed'
+  ) return false
+  if (
+    candidate.stage !== 'startup'
+    && candidate.stage !== 'execution'
+    && candidate.stage !== 'aggregation'
+    && candidate.stage !== 'transfer'
+  ) return false
+  return (
+    (candidate.origin === 'central' && candidate.code === 'central_computation_failed')
+    || (candidate.origin === 'site' && candidate.code === 'participant_computation_failed')
+  )
+}
+
+export const extractSharedError = (logs: string, fallback: string): string => {
+  const encodedLines = logs
+    .split(/\r?\n/)
+    .map((line) => line.replace(DOCKER_TIMESTAMP_PREFIX, ''))
+    .filter((line) => line.startsWith(SHARED_ERROR_PREFIX))
+  for (const line of encodedLines) {
+    try {
+      const envelope: unknown = JSON.parse(line.slice(SHARED_ERROR_PREFIX.length))
+      if (isSharedErrorEnvelope(envelope)) {
+        return ERROR_MESSAGES[envelope.code][envelope.stage]
+      }
+    } catch {
+      // Ignore malformed computation output and use an orchestrator-owned fallback.
+    }
+  }
+  return fallback
+}

--- a/vaultFederatedClient/src/runCoordinator/report/reportRunError.ts
+++ b/vaultFederatedClient/src/runCoordinator/report/reportRunError.ts
@@ -17,8 +17,8 @@ interface ReportRunErrorResponse {
 
 // GraphQL mutation
 const REPORT_RUN_ERROR_MUTATION = `
-  mutation reportRunError($runId: String!, $errorMessage: String!) {
-    reportRunError(runId: $runId, errorMessage: $errorMessage)
+  mutation reportRunError($runId: String!, $errorMessage: String!, $redactErrorDetails: Boolean!) {
+    reportRunError(runId: $runId, errorMessage: $errorMessage, redactErrorDetails: $redactErrorDetails)
   }
 `
 
@@ -38,7 +38,7 @@ export default async function reportRunError({
       },
       body: JSON.stringify({
         query: REPORT_RUN_ERROR_MUTATION,
-        variables: { runId, errorMessage },
+        variables: { runId, errorMessage, redactErrorDetails: true },
       }),
     })
 

--- a/vaultFederatedClient/tests/sharedError.test.mjs
+++ b/vaultFederatedClient/tests/sharedError.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { extractSharedError } from '../dist/runCoordinator/nodeManager/sharedError.js'
+
+test('accepts only allowlisted shared-error envelopes', () => {
+  const valid = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"transfer","code":"participant_computation_failed"}'
+  assert.equal(
+    extractSharedError(valid, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+  assert.equal(
+    extractSharedError(`ordinary log line\n2026-08-06T23:59:00.123456789Z ${valid}`, 'fallback'),
+    'Participant computation failed during artifact transfer',
+  )
+
+  const arbitrary = 'NEUROFLAME_SHARED_ERROR:"patient subject-123"'
+  assert.equal(extractSharedError(arbitrary, 'fallback'), 'fallback')
+
+  const injectedStage = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"subject-123","code":"participant_computation_failed"}'
+  assert.equal(extractSharedError(injectedStage, 'fallback'), 'fallback')
+
+  const mismatchedOrigin = 'NEUROFLAME_SHARED_ERROR:{"schema_version":1,"origin":"site","stage":"execution","code":"central_computation_failed"}'
+  assert.equal(extractSharedError(mismatchedOrigin, 'fallback'), 'fallback')
+
+  assert.equal(
+    extractSharedError(`not-a-docker-timestamp ${valid}`, 'fallback'),
+    'fallback',
+  )
+})


### PR DESCRIPTION
## Summary

  Updates the NeuroFLAME services and desktop application to support computation images using the NVFlare 2.8 wrapper and its versioned
  computation contract.

  ## Changes

  ### Computation image compatibility

  - Adds OCI metadata preflight validation before provisioning or downloading run data.
  - Requires computation images to declare:
    - computation version
    - computation API version
    - boilerplate version
    - NVFlare version
    - source repository and revision
  - Resolves image tags to immutable registry digests.
  - Stores the resolved digest and metadata snapshot with the run.
  - Distributes the same digest to every participant.
  - Revalidates Docker image labels at each client.
  - Keys Singularity/Apptainer images by digest to prevent stale cache reuse.
  - Rejects incompatible or incomplete images before data is mounted.

  The initial computation API version is `0.1.0`.

  ### Application/API compatibility

  - Adds `GET /version` to the central API.
  - Requires the desktop application and central API major/minor versions to match.
  - Allows patch-version differences.
  - Blocks embedded edge-client startup on a confirmed incompatibility.
  - Directs users to the latest NeuroFLAME release when the desktop application is outdated.
  - Treats API connection failures as normal connection failures rather than misleading update warnings.
  - Adds a release-time application/API version consistency check.

  ### Desktop automatic updates

  - Adds automatic update checks at startup and every six hours.
  - Downloads updates in the background.
  - Prompts users to restart immediately or install on normal quit.
  - Supports:
    - Linux AppImage with `latest-linux.yml`
    - macOS DMG/ZIP with `latest-mac.yml`
    - Windows NSIS with `latest.yml`
  - Linux auto-update is enabled only when the AppImage and its containing directory are writable.

  ### Runtime security and cleanup

  - Mounts computation datasets read-only.
  - Drops all Docker capabilities.
  - Enables `no-new-privileges`.
  - Uses owner-only permissions for run directories and retained failure logs.
  - Removes completed containers automatically.
  - Captures up to 1 MiB of failed-container logs in the failed run directory before removal.
  - Treats run kits, logs, results, and error artifacts as sensitive run data.
  - Awaits asynchronous completion and failure reporting so notification errors are not lost.

  ### Run coordination reliability

  - Releases reserved federation ports in `finally`.
  - Awaits socket closure before starting the central container.
  - Propagates resolved computation image metadata through GraphQL and all run coordinators.
  - Improves Docker and Singularity failure handling.
  - Updates provisioning and run-start integration for the NVFlare 2.8 wrapper.

  ## Compatibility and rollout

  This is a coordinated update:

  - Central API, central client, edge clients, vault clients, and desktop applications should be updated together.
  - Computation images must be rebuilt with the new boilerplate publishing scripts so the required OCI labels are present.
  - Existing unlabeled computation images will be rejected during preflight.
  - This change does not add backward compatibility for older computation contracts.

  ## Verification

  - TypeScript compilation passed.
  - Changed-file ESLint checks passed.
  - Desktop compatibility and auto-update unit tests passed: 8 tests.
  - Linux x64 AppImage packaging completed successfully.
  - Verified the packaged application contains `electron-updater`.
  - Verified generation of `app-update.yml` and `latest-linux.yml`.
  - Verified generated build artifacts remain untracked.
